### PR TITLE
Audit P2: de-drift the API and UI before Epic 2.5 / 5.1 freeze the contracts

### DIFF
--- a/e2e/events.spec.ts
+++ b/e2e/events.spec.ts
@@ -1,6 +1,6 @@
 import { type Page, expect, test } from "@playwright/test";
 
-import { resetRateLimits } from "./helpers/db";
+import { deleteNonSeedRows, resetRateLimits } from "./helpers/db";
 
 // Tests share state — created events are used in later tests
 test.describe.configure({ mode: "serial" });
@@ -26,6 +26,15 @@ async function openTypeCombobox(page: Page) {
   // It is the first custom combobox on the form
   await page.getByText("Typ").locator("..").getByRole("combobox").click();
 }
+
+const SEED_PROJECT = "seed-project-demo";
+
+// These specs create events and never remove them, so they accumulate in the
+// shared demo project across runs until the seeded fixtures fall off page one
+// of every list. Start from a known state (see deleteNonSeedRows).
+test.beforeAll(async () => {
+  await deleteNonSeedRows("events", SEED_PROJECT);
+});
 
 test.beforeEach(async ({ context, page }) => {
   await resetRateLimits();
@@ -503,7 +512,7 @@ test.describe("TC-E-13: EventType settings CRUD", () => {
     await page
       .getByRole("row")
       .filter({ hasText: "Expedition" })
-      .getByRole("button", { name: /Edit/ })
+      .getByRole("button", { name: /Bearbeiten/ })
       .click();
 
     // Row is now in edit mode — get the active textbox (input with current value)
@@ -518,7 +527,7 @@ test.describe("TC-E-13: EventType settings CRUD", () => {
     await page
       .getByRole("row")
       .filter({ hasText: "Krieg" })
-      .getByRole("button", { name: /Delete/ })
+      .getByRole("button", { name: /Löschen/ })
       .click();
 
     await expect(page.getByText(/wird von.*Ereignissen verwendet|used by.*events/i)).toBeVisible({
@@ -529,7 +538,7 @@ test.describe("TC-E-13: EventType settings CRUD", () => {
     await page
       .getByRole("row")
       .filter({ hasText: "Forschung" })
-      .getByRole("button", { name: /Delete/ })
+      .getByRole("button", { name: /Löschen/ })
       .click();
 
     // AlertDialog should appear

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -166,24 +166,40 @@ export async function resetRateLimits(): Promise<void> {
 }
 
 /**
- * Removes relations left behind by earlier E2E runs, keeping seeded rows.
+ * Entity tables an E2E spec may purge, mapped to the cache prefix their list
+ * endpoint writes. Allow-listed because the table name is interpolated.
+ */
+const PURGEABLE = {
+  relations: "relation-list",
+  events: "event-list",
+  persons: "person-list",
+  sources: "source-list",
+} as const;
+
+export type PurgeableTable = keyof typeof PURGEABLE;
+
+/**
+ * Removes rows left behind by earlier E2E runs, keeping seeded ones.
  *
- * The relation specs create relations and never delete them, so they pile up in
- * the shared demo project run after run. RelationsTab lists at most 20 per page
- * ordered by created_at DESC, so once ~20 have accumulated the *seeded*
- * relations fall off page one and stop rendering — which is how TC-2.4-05
- * started failing with "was colleague of" not found while the outgoing section
- * showed 21 identical Humboldt→Caroline rows.
+ * The specs create entities and never delete them, so they pile up in the
+ * shared demo project run after run. Every list is paginated and ordered
+ * newest-first, so once enough have accumulated the *seeded* fixtures fall off
+ * page one and stop rendering. That is not hypothetical: TC-2.4-05 failed with
+ * 21 duplicate relations burying the seeded one, and TC-E-10 failed with the
+ * events list reporting "Seite 1 / 35".
  *
- * relation_evidence cascades on relation delete, so this needs no second pass.
- * Also drops the cached relation lists, otherwise the first read after the
+ * Scoped to `project_id = <demo> AND id NOT LIKE 'seed-%'`, so seeded fixtures
+ * and every other project are untouched. relation_evidence cascades, and
+ * events.parent_id is an optional relation (SetNull), so no ordering is needed.
+ *
+ * Also drops the matching cached lists — otherwise the first read after the
  * purge can still be served from the 60s cache.
  */
-export async function deleteNonSeedRelations(projectId: string): Promise<void> {
+export async function deleteNonSeedRows(table: PurgeableTable, projectId: string): Promise<void> {
   const client = getClient();
   await client.connect();
   try {
-    await client.query(`DELETE FROM relations WHERE project_id = $1 AND id NOT LIKE 'seed-%'`, [
+    await client.query(`DELETE FROM ${table} WHERE project_id = $1 AND id NOT LIKE 'seed-%'`, [
       projectId,
     ]);
   } finally {
@@ -197,7 +213,7 @@ export async function deleteNonSeedRelations(projectId: string): Promise<void> {
   let cursor = "0";
   do {
     const scanUrl = new URL(`${url}/scan/${cursor}`);
-    scanUrl.searchParams.set("match", `cache:relation-list:${projectId}:*`);
+    scanUrl.searchParams.set("match", `cache:${PURGEABLE[table]}:${projectId}:*`);
     scanUrl.searchParams.set("count", "100");
     const res = await fetch(scanUrl, { headers });
     const { result } = (await res.json()) as { result: [string, string[]] };
@@ -211,6 +227,11 @@ export async function deleteNonSeedRelations(projectId: string): Promise<void> {
       });
     }
   } while (cursor !== "0");
+}
+
+/** Back-compat wrapper used by relations.spec. */
+export async function deleteNonSeedRelations(projectId: string): Promise<void> {
+  await deleteNonSeedRows("relations", projectId);
 }
 
 /**

--- a/e2e/persons.spec.ts
+++ b/e2e/persons.spec.ts
@@ -1,6 +1,6 @@
 import { type Page, expect, test } from "@playwright/test";
 
-import { resetRateLimits } from "./helpers/db";
+import { deleteNonSeedRows, resetRateLimits } from "./helpers/db";
 
 // Tests share state (persons created in early tests are used in later tests)
 test.describe.configure({ mode: "serial" });
@@ -18,6 +18,15 @@ async function loginAsAdmin(page: Page) {
   await page.getByRole("button", { name: "Anmelden" }).click();
   await page.waitForURL(/\/de\/dashboard/, { timeout: 15_000 });
 }
+
+const SEED_PROJECT = "seed-project-demo";
+
+// These specs create persons and never remove them, so they accumulate in the
+// shared demo project across runs until the seeded fixtures fall off page one
+// of every list. Start from a known state (see deleteNonSeedRows).
+test.beforeAll(async () => {
+  await deleteNonSeedRows("persons", SEED_PROJECT);
+});
 
 test.beforeEach(async ({ context, page }) => {
   await resetRateLimits();

--- a/e2e/security.spec.ts
+++ b/e2e/security.spec.ts
@@ -83,9 +83,11 @@ test.describe("SEC-05: Rate limiting on POST /api/auth/register", () => {
     }
 
     expect(lastResponse!.status()).toBe(429);
-    const body = await lastResponse!.json();
-    expect(body.error).toBe("auth.errors.rateLimited");
-    expect(typeof body.retryAfter).toBe("number");
+    const body = (await lastResponse!.json()) as {
+      error: { code: string; details: { retryAfter: number } };
+    };
+    expect(body.error.code).toBe("RATE_LIMITED");
+    expect(typeof body.error.details.retryAfter).toBe("number");
 
     // Verify rate limit response headers
     expect(lastResponse!.headers()["retry-after"]).toBeTruthy();

--- a/e2e/sources.spec.ts
+++ b/e2e/sources.spec.ts
@@ -1,6 +1,6 @@
 import { type Page, expect, test } from "@playwright/test";
 
-import { resetRateLimits } from "./helpers/db";
+import { deleteNonSeedRows, resetRateLimits } from "./helpers/db";
 
 // Tests share state — created sources are used in later tests
 test.describe.configure({ mode: "serial" });
@@ -20,6 +20,15 @@ async function loginAsAdmin(page: Page) {
   await page.getByRole("button", { name: "Anmelden" }).click();
   await page.waitForURL(/\/de\/dashboard/, { timeout: 15_000 });
 }
+
+const SEED_PROJECT = "seed-project-demo";
+
+// These specs create sources and never remove them, so they accumulate in the
+// shared demo project across runs until the seeded fixtures fall off page one
+// of every list. Start from a known state (see deleteNonSeedRows).
+test.beforeAll(async () => {
+  await deleteNonSeedRows("sources", SEED_PROJECT);
+});
 
 test.beforeEach(async ({ context, page }) => {
   await resetRateLimits();

--- a/messages/de.json
+++ b/messages/de.json
@@ -5,7 +5,15 @@
     "tryAgain": "Erneut versuchen",
     "backToHome": "Zur Startseite",
     "notFound": "Seite nicht gefunden",
-    "notFoundDescription": "Die angeforderte Seite existiert nicht."
+    "notFoundDescription": "Die angeforderte Seite existiert nicht.",
+    "cancel": "Abbrechen",
+    "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten.",
+    "select_all": "Alle auswählen",
+    "select_row": "Zeile auswählen",
+    "edit": "Bearbeiten",
+    "delete": "Löschen",
+    "main_navigation": "Hauptnavigation",
+    "year_format": "JJJJ"
   },
   "shell": {
     "nav": {
@@ -492,7 +500,9 @@
       "range": "{from} – {to}"
     },
     "save_failed": "Relation konnte nicht gespeichert werden.",
-    "delete_failed": "Relation konnte nicht gelöscht werden."
+    "delete_failed": "Relation konnte nicht gelöscht werden.",
+    "year_placeholder": "Jahr",
+    "month_placeholder": "Monat"
   },
   "relationTypes": {
     "title": "Relationstypen",
@@ -542,7 +552,12 @@
     },
     "noEvidence": "Keine Belege für dieses Feld.",
     "saved_toast": "Beleg gespeichert.",
-    "deleted_toast": "Beleg gelöscht."
+    "deleted_toast": "Beleg gelöscht.",
+    "delete_failed": "Konnte nicht gelöscht werden.",
+    "save_failed": "Konnte nicht gespeichert werden.",
+    "search_source": "Quelle suchen…",
+    "page_reference_placeholder": "z. B. S. 42, fol. 3v",
+    "quote_placeholder": "Relevantes Zitat"
   },
   "entityActivity": {
     "title": "Verlauf",
@@ -552,5 +567,17 @@
       "DELETE": "gelöscht"
     },
     "noActivity": "Kein Verlauf vorhanden."
+  },
+  "entitySelector": {
+    "placeholder": "Entität auswählen…",
+    "search": "Suchen…",
+    "searching": "Suche…",
+    "no_results": "Keine Ergebnisse.",
+    "clear": "Auswahl entfernen"
+  },
+  "pagination": {
+    "previous": "Zurück",
+    "next": "Weiter",
+    "page": "Seite"
   }
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -491,7 +491,8 @@
       "to_only": "bis {year}",
       "range": "{from} – {to}"
     },
-    "save_failed": "Relation konnte nicht gespeichert werden."
+    "save_failed": "Relation konnte nicht gespeichert werden.",
+    "delete_failed": "Relation konnte nicht gelöscht werden."
   },
   "relationTypes": {
     "title": "Relationstypen",
@@ -522,7 +523,8 @@
       "LOCATION": "Ort",
       "LITERATURE": "Literatur"
     },
-    "save_failed": "Relationstyp konnte nicht gespeichert werden."
+    "save_failed": "Relationstyp konnte nicht gespeichert werden.",
+    "delete_failed": "Relationstyp konnte nicht gelöscht werden."
   },
   "propertyEvidence": {
     "title": "Nachweise",

--- a/messages/en.json
+++ b/messages/en.json
@@ -491,7 +491,8 @@
       "to_only": "until {year}",
       "range": "{from} – {to}"
     },
-    "save_failed": "Relation could not be saved."
+    "save_failed": "Relation could not be saved.",
+    "delete_failed": "Relation could not be deleted."
   },
   "relationTypes": {
     "title": "Relation types",
@@ -522,7 +523,8 @@
       "LOCATION": "Location",
       "LITERATURE": "Literature"
     },
-    "save_failed": "Relation type could not be saved."
+    "save_failed": "Relation type could not be saved.",
+    "delete_failed": "Relation type could not be deleted."
   },
   "propertyEvidence": {
     "title": "Evidence",

--- a/messages/en.json
+++ b/messages/en.json
@@ -5,7 +5,15 @@
     "tryAgain": "Try again",
     "backToHome": "Back to home",
     "notFound": "Page not found",
-    "notFoundDescription": "The requested page does not exist."
+    "notFoundDescription": "The requested page does not exist.",
+    "cancel": "Cancel",
+    "unexpectedError": "An unexpected error occurred.",
+    "select_all": "Select all",
+    "select_row": "Select row",
+    "edit": "Edit",
+    "delete": "Delete",
+    "main_navigation": "Main navigation",
+    "year_format": "YYYY"
   },
   "shell": {
     "nav": {
@@ -492,7 +500,9 @@
       "range": "{from} – {to}"
     },
     "save_failed": "Relation could not be saved.",
-    "delete_failed": "Relation could not be deleted."
+    "delete_failed": "Relation could not be deleted.",
+    "year_placeholder": "Year",
+    "month_placeholder": "Month"
   },
   "relationTypes": {
     "title": "Relation types",
@@ -542,7 +552,12 @@
     },
     "noEvidence": "No evidence for this field.",
     "saved_toast": "Evidence saved.",
-    "deleted_toast": "Evidence deleted."
+    "deleted_toast": "Evidence deleted.",
+    "delete_failed": "Could not be deleted.",
+    "save_failed": "Could not be saved.",
+    "search_source": "Search source…",
+    "page_reference_placeholder": "e.g. p. 42, fol. 3v",
+    "quote_placeholder": "Relevant quotation"
   },
   "entityActivity": {
     "title": "Activity",
@@ -552,5 +567,17 @@
       "DELETE": "deleted"
     },
     "noActivity": "No activity yet."
+  },
+  "entitySelector": {
+    "placeholder": "Select entity…",
+    "search": "Search…",
+    "searching": "Searching…",
+    "no_results": "No results.",
+    "clear": "Clear selection"
+  },
+  "pagination": {
+    "previous": "Previous",
+    "next": "Next",
+    "page": "Page"
   }
 }

--- a/src/app/[locale]/(app)/events/page.tsx
+++ b/src/app/[locale]/(app)/events/page.tsx
@@ -9,9 +9,15 @@ import { prisma } from "@/lib/db";
 import type { EventSummary } from "@/types/event";
 import type { EventType } from "@/types/event-type";
 
-export const metadata: Metadata = {
-  title: "Ereignisse",
-};
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "events" });
+  return { title: t("title") };
+}
 
 interface PageProps {
   params: Promise<{ locale: string }>;
@@ -145,7 +151,7 @@ export default async function EventsPage({ params, searchParams }: PageProps) {
         <h1 className="text-2xl font-bold">{t("title")}</h1>
         <Link
           href={`/${locale}/events/new`}
-          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium"
         >
           {t("create")}
         </Link>

--- a/src/app/[locale]/(app)/persons/page.tsx
+++ b/src/app/[locale]/(app)/persons/page.tsx
@@ -9,9 +9,15 @@ import { cache } from "@/lib/cache";
 import { db, prisma } from "@/lib/db";
 import type { PersonSummary } from "@/types/person";
 
-export const metadata: Metadata = {
-  title: "Personen",
-};
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "persons" });
+  return { title: t("title") };
+}
 
 interface PageProps {
   params: Promise<{ locale: string }>;

--- a/src/app/[locale]/(app)/relations/_components/RelationsDataTable.tsx
+++ b/src/app/[locale]/(app)/relations/_components/RelationsDataTable.tsx
@@ -50,10 +50,10 @@ export function RelationsDataTable({ projectId }: RelationsDataTableProps) {
       if (res.ok) {
         const data = (await res.json()) as {
           data?: RelationWithDetails[];
-          total?: number;
+          pagination?: { total: number };
         };
         setRelations(data.data ?? []);
-        setTotal(data.total ?? 0);
+        setTotal(data.pagination?.total ?? 0);
       }
     } finally {
       setLoading(false);

--- a/src/app/[locale]/(app)/relations/_components/RelationsDataTable.tsx
+++ b/src/app/[locale]/(app)/relations/_components/RelationsDataTable.tsx
@@ -8,6 +8,7 @@ import { RelationFormDialog } from "@/components/relations/RelationFormDialog";
 import { RelationRow } from "@/components/relations/RelationRow";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
 import { useRelationTypes } from "@/hooks/use-relation-types";
 import type { RelationWithDetails } from "@/types/relations";
 
@@ -74,27 +75,27 @@ export function RelationsDataTable({ projectId }: RelationsDataTableProps) {
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap gap-2">
-        <select
+        <Select
           value={entityTypeFilter}
           onChange={(e) => {
             setEntityTypeFilter(e.target.value);
             setPage(1);
           }}
-          className="border-input bg-background focus-visible:ring-ring rounded-md border px-3 py-2 text-sm focus-visible:ring-1 focus-visible:outline-none"
+          className="w-auto"
         >
           <option value="">{t("filter.all_entity_types")}</option>
           <option value="PERSON">{t("entityTypes.PERSON")}</option>
           <option value="EVENT">{t("entityTypes.EVENT")}</option>
           <option value="SOURCE">{t("entityTypes.SOURCE")}</option>
-        </select>
+        </Select>
 
-        <select
+        <Select
           value={relationTypeFilter}
           onChange={(e) => {
             setRelationTypeFilter(e.target.value);
             setPage(1);
           }}
-          className="border-input bg-background focus-visible:ring-ring rounded-md border px-3 py-2 text-sm focus-visible:ring-1 focus-visible:outline-none"
+          className="w-auto"
         >
           <option value="">{t("filter.all_types")}</option>
           {allRelationTypes.map((rt) => (
@@ -102,22 +103,22 @@ export function RelationsDataTable({ projectId }: RelationsDataTableProps) {
               {rt.name}
             </option>
           ))}
-        </select>
+        </Select>
 
-        <select
+        <Select
           value={certaintyFilter}
           onChange={(e) => {
             setCertaintyFilter(e.target.value);
             setPage(1);
           }}
-          className="border-input bg-background focus-visible:ring-ring rounded-md border px-3 py-2 text-sm focus-visible:ring-1 focus-visible:outline-none"
+          className="w-auto"
         >
           <option value="">{t("filter.all_certainties")}</option>
           <option value="CERTAIN">{t("certainties.CERTAIN")}</option>
           <option value="PROBABLE">{t("certainties.PROBABLE")}</option>
           <option value="POSSIBLE">{t("certainties.POSSIBLE")}</option>
           <option value="UNKNOWN">{t("certainties.UNKNOWN")}</option>
-        </select>
+        </Select>
       </div>
 
       <div className="flex items-center justify-between gap-2">

--- a/src/app/[locale]/(app)/relations/page.tsx
+++ b/src/app/[locale]/(app)/relations/page.tsx
@@ -5,9 +5,15 @@ import { getTranslations } from "next-intl/server";
 import { RelationsDataTable } from "@/app/[locale]/(app)/relations/_components/RelationsDataTable";
 import { auth } from "@/auth";
 
-export const metadata: Metadata = {
-  title: "Relationen",
-};
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "relations" });
+  return { title: t("title") };
+}
 
 interface PageProps {
   params: Promise<{ locale: string }>;

--- a/src/app/[locale]/(app)/settings/event-types/page.tsx
+++ b/src/app/[locale]/(app)/settings/event-types/page.tsx
@@ -5,9 +5,15 @@ import { getTranslations } from "next-intl/server";
 import { auth } from "@/auth";
 import { EventTypeSettingsTable } from "@/components/research/EventTypeSettingsTable";
 
-export const metadata: Metadata = {
-  title: "Ereignistypen",
-};
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "event_types" });
+  return { title: t("title") };
+}
 
 interface PageProps {
   params: Promise<{ locale: string }>;

--- a/src/app/[locale]/(app)/settings/relation-types/_components/RelationTypeFormDialog.tsx
+++ b/src/app/[locale]/(app)/settings/relation-types/_components/RelationTypeFormDialog.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import type { RelationTypeItem } from "@/types/relations";
 
 interface RelationTypeFormDialogProps {
@@ -135,7 +136,7 @@ export function RelationTypeFormDialog({
           {/* Description */}
           <div className="space-y-1">
             <Label>{t("fields.description")}</Label>
-            <textarea
+            <Textarea
               className="border-input bg-background placeholder:text-muted-foreground focus-visible:ring-ring w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-1 focus-visible:outline-none"
               rows={2}
               value={description}

--- a/src/app/[locale]/(app)/settings/relation-types/_components/RelationTypesTable.tsx
+++ b/src/app/[locale]/(app)/settings/relation-types/_components/RelationTypesTable.tsx
@@ -197,7 +197,7 @@ export function RelationTypesTable({ projectId }: RelationTypesTableProps) {
             <AlertDialogDescription>{t("delete_confirm_body")}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleting}>Abbrechen</AlertDialogCancel>
+            <AlertDialogCancel disabled={deleting}>{t("cancel")}</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => void confirmDelete()}
               disabled={deleting}

--- a/src/app/[locale]/(app)/settings/relation-types/_components/RelationTypesTable.tsx
+++ b/src/app/[locale]/(app)/settings/relation-types/_components/RelationTypesTable.tsx
@@ -45,9 +45,7 @@ export function RelationTypesTable({ projectId }: RelationTypesTableProps) {
     try {
       const res = await fetch(`/api/relation-types?projectId=${encodeURIComponent(projectId)}`);
       if (res.ok) {
-        const data = (await res.json()) as
-          | RelationTypeItem[]
-          | { data?: RelationTypeItem[] };
+        const data = (await res.json()) as RelationTypeItem[] | { data?: RelationTypeItem[] };
         if (Array.isArray(data)) {
           setTypes(data);
         } else if (data && Array.isArray((data as { data?: RelationTypeItem[] }).data)) {
@@ -82,11 +80,10 @@ export function RelationTypesTable({ projectId }: RelationTypesTableProps) {
         setDeleteTarget(null);
         toast.success(t("deleted_toast"));
       } else {
-        const data = (await res.json().catch(() => ({}))) as { error?: string };
         if (res.status === 409) {
           toast.error(t("deleteBlocked", { count: deleteTarget._count.relations }));
         } else {
-          toast.error(data.error ?? "Fehler beim Löschen.");
+          toast.error(t("delete_failed"));
         }
         setDeleteTarget(null);
       }
@@ -97,7 +94,7 @@ export function RelationTypesTable({ projectId }: RelationTypesTableProps) {
 
   if (loading) {
     return (
-      <div className="flex items-center gap-2 py-8 text-muted-foreground">
+      <div className="text-muted-foreground flex items-center gap-2 py-8">
         <Loader2 className="h-4 w-4 animate-spin" />
       </div>
     );
@@ -135,16 +132,16 @@ export function RelationTypesTable({ projectId }: RelationTypesTableProps) {
               <TableCell>
                 {type.color ? (
                   <span
-                    className="inline-block h-5 w-5 rounded-full border border-border"
+                    className="border-border inline-block h-5 w-5 rounded-full border"
                     style={{ backgroundColor: type.color }}
                   />
                 ) : (
-                  <span className="inline-block h-5 w-5 rounded-full border border-dashed border-border" />
+                  <span className="border-border inline-block h-5 w-5 rounded-full border border-dashed" />
                 )}
               </TableCell>
               <TableCell className="font-medium">{type.name}</TableCell>
               <TableCell className="text-muted-foreground">{type.inverse_name ?? "—"}</TableCell>
-              <TableCell className="text-right text-muted-foreground">
+              <TableCell className="text-muted-foreground text-right">
                 {type._count.relations}
               </TableCell>
               <TableCell>
@@ -177,7 +174,7 @@ export function RelationTypesTable({ projectId }: RelationTypesTableProps) {
 
           {types.length === 0 && (
             <TableRow>
-              <TableCell colSpan={5} className="py-8 text-center text-muted-foreground">
+              <TableCell colSpan={5} className="text-muted-foreground py-8 text-center">
                 —
               </TableCell>
             </TableRow>
@@ -196,9 +193,7 @@ export function RelationTypesTable({ projectId }: RelationTypesTableProps) {
       <AlertDialog open={!!deleteTarget} onOpenChange={(o) => !o && setDeleteTarget(null)}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>
-              {t("delete_confirm_title")}
-            </AlertDialogTitle>
+            <AlertDialogTitle>{t("delete_confirm_title")}</AlertDialogTitle>
             <AlertDialogDescription>{t("delete_confirm_body")}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/src/app/[locale]/(app)/settings/relation-types/page.tsx
+++ b/src/app/[locale]/(app)/settings/relation-types/page.tsx
@@ -5,9 +5,15 @@ import { getTranslations } from "next-intl/server";
 import { RelationTypesTable } from "@/app/[locale]/(app)/settings/relation-types/_components/RelationTypesTable";
 import { auth } from "@/auth";
 
-export const metadata: Metadata = {
-  title: "Relationstypen",
-};
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "relationTypes" });
+  return { title: t("title") };
+}
 
 interface PageProps {
   params: Promise<{ locale: string }>;

--- a/src/app/[locale]/(app)/sources/page.tsx
+++ b/src/app/[locale]/(app)/sources/page.tsx
@@ -8,9 +8,15 @@ import { SourceTable } from "@/components/research/SourceTable";
 import { prisma } from "@/lib/db";
 import type { SourceReliability, SourceSummary } from "@/types/source";
 
-export const metadata: Metadata = {
-  title: "Quellen",
-};
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "sources" });
+  return { title: t("title") };
+}
 
 interface PageProps {
   params: Promise<{ locale: string }>;
@@ -101,7 +107,7 @@ export default async function SourcesPage({ params, searchParams }: PageProps) {
         <h1 className="text-2xl font-bold">{t("title")}</h1>
         <Link
           href={`/${locale}/sources/new`}
-          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium"
         >
           {t("create")}
         </Link>

--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -20,12 +20,12 @@ export default function Error({ error, reset }: ErrorProps) {
     <div className="flex min-h-screen items-center justify-center p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="flex flex-row items-center gap-3">
-          <AlertCircle className="h-6 w-6 text-destructive" />
+          <AlertCircle className="text-destructive h-6 w-6" />
           <CardTitle>{t("error")}</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-muted-foreground">
-            {isDev ? error.message : "An unexpected error occurred."}
+          <p className="text-muted-foreground text-sm">
+            {isDev ? error.message : t("unexpectedError")}
           </p>
         </CardContent>
         <CardFooter className="gap-2">

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
+import { jsonError } from "@/lib/api";
 import { writeAuditLog } from "@/lib/audit";
 import { prisma } from "@/lib/db";
 import { sendPasswordResetEmail } from "@/lib/email";
@@ -22,7 +23,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   try {
     body = await request.json();
   } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    return jsonError(400, "INVALID_JSON");
   }
 
   const parsed = forgotPasswordSchema.safeParse(body);
@@ -32,7 +33,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       const field = issue.path[0]?.toString() ?? "unknown";
       fields[field] = issue.message;
     }
-    return NextResponse.json({ error: "Validation failed", fields }, { status: 400 });
+    return jsonError(400, "VALIDATION_FAILED", { details: { fields } });
   }
 
   const { email } = parsed.data;

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -2,6 +2,7 @@ import bcrypt from "bcryptjs";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
+import { jsonError } from "@/lib/api";
 import { writeAuditLog } from "@/lib/audit";
 import { prisma } from "@/lib/db";
 import { sendVerificationEmail } from "@/lib/email";
@@ -36,7 +37,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   try {
     body = await request.json();
   } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    return jsonError(400, "INVALID_JSON");
   }
 
   const parsed = registerSchema.safeParse(body);
@@ -46,7 +47,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       const field = issue.path[0]?.toString() ?? "unknown";
       fields[field] = issue.message;
     }
-    return NextResponse.json({ error: "Validation failed", fields }, { status: 400 });
+    return jsonError(400, "VALIDATION_FAILED", { details: { fields } });
   }
 
   const { email, password } = parsed.data;
@@ -54,7 +55,7 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   const existing = await prisma.user.findUnique({ where: { email } });
   if (existing) {
-    return NextResponse.json({ error: "auth.errors.emailTaken" }, { status: 409 });
+    return jsonError(409, "EMAIL_TAKEN");
   }
 
   const password_hash = await bcrypt.hash(password, env.BCRYPT_ROUNDS);

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -2,6 +2,7 @@ import bcrypt from "bcryptjs";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
+import { jsonError } from "@/lib/api";
 import { writeAuditLog } from "@/lib/audit";
 import { prisma } from "@/lib/db";
 import { env } from "@/lib/env";
@@ -33,7 +34,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   try {
     body = await request.json();
   } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    return jsonError(400, "INVALID_JSON");
   }
 
   const parsed = resetPasswordSchema.safeParse(body);
@@ -43,7 +44,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       const key = issue.path[0]?.toString() ?? "unknown";
       fields[key] = issue.message;
     }
-    return NextResponse.json({ error: "Validation failed", fields }, { status: 400 });
+    return jsonError(400, "VALIDATION_FAILED", { details: { fields } });
   }
 
   const { token, password } = parsed.data;
@@ -61,7 +62,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       request,
       metadata: { token_type: "password_reset", reason: "not_found" },
     });
-    return NextResponse.json({ error: "auth.errors.tokenInvalid" }, { status: 400 });
+    return jsonError(400, "TOKEN_INVALID");
   }
 
   if (resetRow.used_at !== null || resetRow.expires_at <= new Date()) {
@@ -71,7 +72,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       request,
       metadata: { token_type: "password_reset", reason: resetRow.used_at ? "used" : "expired" },
     });
-    return NextResponse.json({ error: "auth.errors.tokenExpired" }, { status: 400 });
+    return jsonError(400, "TOKEN_EXPIRED");
   }
 
   const password_hash = await bcrypt.hash(password, env.BCRYPT_ROUNDS);

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -10,7 +10,10 @@ import { hashToken } from "@/lib/security";
 
 const resetPasswordSchema = z
   .object({
-    token: z.string().length(64).regex(/^[0-9a-f]+$/),
+    token: z
+      .string()
+      .length(64)
+      .regex(/^[0-9a-f]+$/),
     password: z
       .string()
       .min(8)

--- a/src/app/api/auth/verify-email/route.ts
+++ b/src/app/api/auth/verify-email/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
+import { jsonError } from "@/lib/api";
 import { writeAuditLog } from "@/lib/audit";
 import { prisma } from "@/lib/db";
 import { checkRateLimit } from "@/lib/rate-limit";
@@ -27,12 +28,12 @@ export async function POST(request: Request): Promise<NextResponse> {
   try {
     body = await request.json();
   } catch {
-    return NextResponse.json({ error: "auth.errors.tokenInvalid" }, { status: 400 });
+    return jsonError(400, "TOKEN_INVALID");
   }
 
   const parsed = verifyEmailSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json({ error: "auth.errors.tokenInvalid" }, { status: 400 });
+    return jsonError(400, "TOKEN_INVALID");
   }
 
   const tokenHash = hashToken(parsed.data.token);
@@ -47,7 +48,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       request,
       metadata: { token_type: "email_confirmation", reason: "not_found" },
     });
-    return NextResponse.json({ error: "auth.errors.tokenInvalid" }, { status: 400 });
+    return jsonError(400, "TOKEN_INVALID");
   }
 
   if (confirmation.used_at !== null || confirmation.expires_at <= new Date()) {
@@ -60,7 +61,7 @@ export async function POST(request: Request): Promise<NextResponse> {
         reason: confirmation.used_at ? "used" : "expired",
       },
     });
-    return NextResponse.json({ error: "auth.errors.tokenExpired" }, { status: 400 });
+    return jsonError(400, "TOKEN_EXPIRED");
   }
 
   await prisma.$transaction([

--- a/src/app/api/auth/verify-email/route.ts
+++ b/src/app/api/auth/verify-email/route.ts
@@ -7,7 +7,10 @@ import { checkRateLimit } from "@/lib/rate-limit";
 import { anonymizeIp, hashToken } from "@/lib/security";
 
 const verifyEmailSchema = z.object({
-  token: z.string().length(64).regex(/^[0-9a-f]+$/),
+  token: z
+    .string()
+    .length(64)
+    .regex(/^[0-9a-f]+$/),
 });
 
 export async function POST(request: Request): Promise<NextResponse> {
@@ -52,7 +55,10 @@ export async function POST(request: Request): Promise<NextResponse> {
       action: "INVALID_TOKEN",
       userId: confirmation.user_id,
       request,
-      metadata: { token_type: "email_confirmation", reason: confirmation.used_at ? "used" : "expired" },
+      metadata: {
+        token_type: "email_confirmation",
+        reason: confirmation.used_at ? "used" : "expired",
+      },
     });
     return NextResponse.json({ error: "auth.errors.tokenExpired" }, { status: 400 });
   }

--- a/src/app/api/entities/[type]/[id]/activity/route.test.ts
+++ b/src/app/api/entities/[type]/[id]/activity/route.test.ts
@@ -84,11 +84,12 @@ describe("GET /api/entities/[type]/[id]/activity", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       data: { id: string; user_name: string | null }[];
-      total: number;
+      pagination: { page: number; pageSize: number; total: number; totalPages: number };
     };
     expect(body.data).toHaveLength(1);
     expect(body.data[0]?.user_name).toBe("Max Müller");
-    expect(body.total).toBe(1);
+    expect(body.pagination.total).toBe(1);
+    expect(body.pagination.totalPages).toBe(1);
   });
 
   it("is case-insensitive for entity type (person -> PERSON)", async () => {

--- a/src/app/api/entities/[type]/[id]/activity/route.ts
+++ b/src/app/api/entities/[type]/[id]/activity/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest } from "next/server";
 import { z } from "zod";
 
-import { forbidden, json, jsonError, unauthorized } from "@/lib/api";
+import { forbidden, json, jsonError, paginated, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { prisma } from "@/lib/db";
 import { validateEntityExists } from "@/lib/entity-validation";
@@ -91,5 +91,5 @@ export async function GET(request: NextRequest, context: RouteContext) {
     created_at: r.created_at.toISOString(),
   }));
 
-  return json({ data, total, page, pageSize });
+  return json(paginated(data, { page, pageSize, total }));
 }

--- a/src/app/api/entities/[type]/[id]/activity/route.ts
+++ b/src/app/api/entities/[type]/[id]/activity/route.ts
@@ -1,6 +1,7 @@
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
+import { forbidden, json, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { prisma } from "@/lib/db";
 import { validateEntityExists } from "@/lib/entity-validation";
@@ -18,30 +19,22 @@ type RouteContext = { params: Promise<{ type: string; id: string }> };
 
 export async function GET(request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { type: rawType, id } = await context.params;
 
   // Validate entity type (case-insensitive)
   const upperType = rawType.toUpperCase() as ValidEntityType;
   if (!VALID_ENTITY_TYPES.includes(upperType)) {
-    return NextResponse.json(
-      { error: "Invalid entity type", valid: VALID_ENTITY_TYPES },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return json({ error: "Invalid entity type", valid: VALID_ENTITY_TYPES }, { status: 400 });
   }
 
   const { searchParams } = request.nextUrl;
   const parsed = listQuerySchema.safeParse(Object.fromEntries(searchParams));
   if (!parsed.success) {
-    return NextResponse.json(
+    return json(
       { error: "Invalid query params", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
+      { status: 400 },
     );
   }
 
@@ -52,19 +45,13 @@ export async function GET(request: NextRequest, context: RouteContext) {
     where: { user_id: user.id, project_id: projectId },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   // Verify entity exists
   const entityExists = await validateEntityExists(upperType, id, projectId);
   if (!entityExists) {
-    return NextResponse.json(
-      { error: "Entity not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return json({ error: "Entity not found" }, { status: 404 });
   }
 
   const [records, total] = await Promise.all([
@@ -107,8 +94,5 @@ export async function GET(request: NextRequest, context: RouteContext) {
     created_at: r.created_at.toISOString(),
   }));
 
-  return NextResponse.json(
-    { data, total, page, pageSize },
-    { status: 200, headers: { "Cache-Control": "no-store" } },
-  );
+  return json({ data, total, page, pageSize });
 }

--- a/src/app/api/entities/[type]/[id]/activity/route.ts
+++ b/src/app/api/entities/[type]/[id]/activity/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest } from "next/server";
 import { z } from "zod";
 
-import { forbidden, json, unauthorized } from "@/lib/api";
+import { forbidden, json, jsonError, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { prisma } from "@/lib/db";
 import { validateEntityExists } from "@/lib/entity-validation";
@@ -26,16 +26,13 @@ export async function GET(request: NextRequest, context: RouteContext) {
   // Validate entity type (case-insensitive)
   const upperType = rawType.toUpperCase() as ValidEntityType;
   if (!VALID_ENTITY_TYPES.includes(upperType)) {
-    return json({ error: "Invalid entity type", valid: VALID_ENTITY_TYPES }, { status: 400 });
+    return jsonError(400, "INVALID_ENTITY_TYPE", { details: { valid: VALID_ENTITY_TYPES } });
   }
 
   const { searchParams } = request.nextUrl;
   const parsed = listQuerySchema.safeParse(Object.fromEntries(searchParams));
   if (!parsed.success) {
-    return json(
-      { error: "Invalid query params", details: parsed.error.flatten() },
-      { status: 400 },
-    );
+    return jsonError(400, "INVALID_QUERY_PARAMS", { details: parsed.error.flatten() });
   }
 
   const { projectId, page, pageSize } = parsed.data;
@@ -51,7 +48,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
   // Verify entity exists
   const entityExists = await validateEntityExists(upperType, id, projectId);
   if (!entityExists) {
-    return json({ error: "Entity not found" }, { status: 404 });
+    return jsonError(404, "ENTITY_NOT_FOUND");
   }
 
   const [records, total] = await Promise.all([

--- a/src/app/api/event-types/[id]/route.test.ts
+++ b/src/app/api/event-types/[id]/route.test.ts
@@ -92,13 +92,11 @@ describe("DELETE /api/event-types/[id]", () => {
 
     expect(res.status).toBe(409);
     const body = (await res.json()) as {
-      error: string;
-      count: number;
-      filter_url: string;
+      error: { code: string; details: { count: number; filter_url: string } };
     };
-    expect(body.error).toBe("TYPE_IN_USE");
-    expect(body.count).toBe(5);
-    expect(body.filter_url).toContain("et-1");
+    expect(body.error.code).toBe("IN_USE");
+    expect(body.error.details.count).toBe(5);
+    expect(body.error.details.filter_url).toContain("et-1");
   });
 
   it("deletes unused type and returns 200 with deleted:true", async () => {

--- a/src/app/api/event-types/[id]/route.ts
+++ b/src/app/api/event-types/[id]/route.ts
@@ -1,7 +1,8 @@
 import { Prisma } from "@prisma/client";
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
+import { forbidden, json, jsonError, notFoundError, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { prisma } from "@/lib/db";
@@ -32,12 +33,7 @@ type RouteContext = { params: Promise<{ id: string }> };
 
 export async function PUT(request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -45,38 +41,23 @@ export async function PUT(request: NextRequest, context: RouteContext) {
     where: { id },
   });
   if (!existing) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: existing.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON" },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.data;
 
   const parsed = updateEventTypeSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -100,10 +81,7 @@ export async function PUT(request: NextRequest, context: RouteContext) {
       "code" in err &&
       (err as { code: string }).code === "P2002"
     ) {
-      return NextResponse.json(
-        { error: "DUPLICATE_NAME" },
-        { status: 409, headers: { "Cache-Control": "no-store" } },
-      );
+      return json({ error: "DUPLICATE_NAME" }, { status: 409 });
     }
     throw err;
   }
@@ -117,26 +95,18 @@ export async function PUT(request: NextRequest, context: RouteContext) {
   // doesn't immediately read back their own stale edit.
   await cache.invalidateByPrefix(`event-list:${existing.project_id}:`);
 
-  return NextResponse.json(
-    {
-      id: updated.id,
-      name: updated.name,
-      color: updated.color,
-      icon: updated.icon,
-      event_count: eventCount,
-    },
-    { status: 200, headers: { "Cache-Control": "no-store" } },
-  );
+  return json({
+    id: updated.id,
+    name: updated.name,
+    color: updated.color,
+    icon: updated.icon,
+    event_count: eventCount,
+  });
 }
 
 export async function DELETE(_request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -144,20 +114,14 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     where: { id },
   });
   if (!existing) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: existing.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   // Count non-deleted events using this type
@@ -166,13 +130,13 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
   });
 
   if (eventCount > 0) {
-    return NextResponse.json(
+    return json(
       {
         error: "TYPE_IN_USE",
         count: eventCount,
         filter_url: `/events?typeIds=${id}`,
       },
-      { status: 409, headers: { "Cache-Control": "no-store" } },
+      { status: 409 },
     );
   }
 
@@ -182,10 +146,7 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     where: { event_type_id: id, deleted_at: { not: null } },
   });
   if (softDeletedCount > 0) {
-    return NextResponse.json(
-      { error: "TYPE_IN_USE_BY_DELETED", count: softDeletedCount },
-      { status: 409, headers: { "Cache-Control": "no-store" } },
-    );
+    return json({ error: "TYPE_IN_USE_BY_DELETED", count: softDeletedCount }, { status: 409 });
   }
 
   try {
@@ -194,16 +155,10 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     });
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2003") {
-      return NextResponse.json(
-        { error: "TYPE_IN_USE" },
-        { status: 409, headers: { "Cache-Control": "no-store" } },
-      );
+      return json({ error: "TYPE_IN_USE" }, { status: 409 });
     }
     throw error;
   }
 
-  return NextResponse.json(
-    { deleted: true },
-    { status: 200, headers: { "Cache-Control": "no-store" } },
-  );
+  return json({ deleted: true });
 }

--- a/src/app/api/event-types/[id]/route.ts
+++ b/src/app/api/event-types/[id]/route.ts
@@ -57,7 +57,7 @@ export async function PUT(request: NextRequest, context: RouteContext) {
 
   const parsed = updateEventTypeSchema.safeParse(body);
   if (!parsed.success) {
-    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
+    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -81,7 +81,7 @@ export async function PUT(request: NextRequest, context: RouteContext) {
       "code" in err &&
       (err as { code: string }).code === "P2002"
     ) {
-      return json({ error: "DUPLICATE_NAME" }, { status: 409 });
+      return jsonError(409, "DUPLICATE_NAME");
     }
     throw err;
   }
@@ -130,14 +130,9 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
   });
 
   if (eventCount > 0) {
-    return json(
-      {
-        error: "TYPE_IN_USE",
-        count: eventCount,
-        filter_url: `/events?typeIds=${id}`,
-      },
-      { status: 409 },
-    );
+    return jsonError(409, "IN_USE", {
+      details: { count: eventCount, filter_url: `/events?typeIds=${id}` },
+    });
   }
 
   // Soft-deleted events still hold the FK (onDelete: Restrict), so a hard
@@ -146,7 +141,7 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     where: { event_type_id: id, deleted_at: { not: null } },
   });
   if (softDeletedCount > 0) {
-    return json({ error: "TYPE_IN_USE_BY_DELETED", count: softDeletedCount }, { status: 409 });
+    return jsonError(409, "IN_USE_BY_DELETED", { details: { count: softDeletedCount } });
   }
 
   try {
@@ -155,7 +150,7 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     });
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2003") {
-      return json({ error: "TYPE_IN_USE" }, { status: 409 });
+      return jsonError(409, "IN_USE");
     }
     throw error;
   }

--- a/src/app/api/event-types/route.test.ts
+++ b/src/app/api/event-types/route.test.ts
@@ -138,8 +138,8 @@ describe("POST /api/event-types", () => {
     const res = await POST(req);
 
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Validation failed");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("VALIDATION_FAILED");
   });
 
   it("returns 409 DUPLICATE_NAME when Prisma throws P2002", async () => {
@@ -155,8 +155,8 @@ describe("POST /api/event-types", () => {
     const res = await POST(req);
 
     expect(res.status).toBe(409);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("DUPLICATE_NAME");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("DUPLICATE_NAME");
   });
 
   it("returns 400 when name is missing", async () => {
@@ -167,7 +167,7 @@ describe("POST /api/event-types", () => {
     const res = await POST(req);
 
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Validation failed");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("VALIDATION_FAILED");
   });
 });

--- a/src/app/api/event-types/route.ts
+++ b/src/app/api/event-types/route.ts
@@ -1,7 +1,8 @@
 import { type Prisma } from "@prisma/client";
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
+import { forbidden, json, jsonError, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { prisma } from "@/lib/db";
 import { sanitize } from "@/lib/sanitize";
@@ -30,20 +31,12 @@ const createEventTypeSchema = z.object({
 
 export async function GET(request: NextRequest) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { searchParams } = request.nextUrl;
   const projectId = searchParams.get("projectId") ?? user.projectId;
   if (!projectId) {
-    return NextResponse.json(
-      { error: "No project" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return json({ error: "No project" }, { status: 403 });
   }
 
   // Check project membership
@@ -51,10 +44,7 @@ export async function GET(request: NextRequest) {
     where: { user_id: user.id, project_id: projectId },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   const eventTypes = await prisma.eventType.findMany({
@@ -75,34 +65,20 @@ export async function GET(request: NextRequest) {
     event_count: et._count.events,
   }));
 
-  return NextResponse.json({ data }, { status: 200, headers: { "Cache-Control": "no-store" } });
+  return json({ data });
 }
 
 export async function POST(request: NextRequest) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON" },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.data;
 
   const parsed = createEventTypeSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -112,10 +88,7 @@ export async function POST(request: NextRequest) {
     where: { user_id: user.id, project_id: data.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   let eventType: Prisma.EventTypeGetPayload<Record<string, never>>;
@@ -136,15 +109,12 @@ export async function POST(request: NextRequest) {
       "code" in err &&
       (err as { code: string }).code === "P2002"
     ) {
-      return NextResponse.json(
-        { error: "DUPLICATE_NAME" },
-        { status: 409, headers: { "Cache-Control": "no-store" } },
-      );
+      return json({ error: "DUPLICATE_NAME" }, { status: 409 });
     }
     throw err;
   }
 
-  return NextResponse.json(
+  return json(
     {
       id: eventType.id,
       name: eventType.name,
@@ -152,6 +122,6 @@ export async function POST(request: NextRequest) {
       icon: eventType.icon,
       event_count: 0,
     },
-    { status: 201, headers: { "Cache-Control": "no-store" } },
+    { status: 201 },
   );
 }

--- a/src/app/api/event-types/route.ts
+++ b/src/app/api/event-types/route.ts
@@ -36,7 +36,7 @@ export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const projectId = searchParams.get("projectId") ?? user.projectId;
   if (!projectId) {
-    return json({ error: "No project" }, { status: 403 });
+    return jsonError(403, "NO_PROJECT");
   }
 
   // Check project membership
@@ -78,7 +78,7 @@ export async function POST(request: NextRequest) {
 
   const parsed = createEventTypeSchema.safeParse(body);
   if (!parsed.success) {
-    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
+    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -109,7 +109,7 @@ export async function POST(request: NextRequest) {
       "code" in err &&
       (err as { code: string }).code === "P2002"
     ) {
-      return json({ error: "DUPLICATE_NAME" }, { status: 409 });
+      return jsonError(409, "DUPLICATE_NAME");
     }
     throw err;
   }

--- a/src/app/api/events/[id]/route.test.ts
+++ b/src/app/api/events/[id]/route.test.ts
@@ -101,9 +101,9 @@ describe("DELETE /api/events/[id]", () => {
     const res = await DELETE(req, makeContext("evt-1"));
 
     expect(res.status).toBe(409);
-    const body = (await res.json()) as { error: string; count: number };
-    expect(body.error).toBe("HAS_SUB_EVENTS");
-    expect(body.count).toBe(3);
+    const body = (await res.json()) as { error: { code: string; details: { count: number } } };
+    expect(body.error.code).toBe("HAS_SUB_EVENTS");
+    expect(body.error.details.count).toBe(3);
   });
 
   it("soft-deletes event and invalidates cache when event has no sub-events", async () => {

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -1,7 +1,8 @@
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
 import { logActivity } from "@/lib/activity";
+import { forbidden, json, jsonError, notFoundError, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { db, prisma } from "@/lib/db";
@@ -115,12 +116,7 @@ function buildEventSummary(event: {
 
 export async function GET(_request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -130,10 +126,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   });
 
   if (!event) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   // Check project membership
@@ -141,10 +134,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     where: { user_id: user.id, project_id: event.project_id },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   const [relationsFromCount, relationsToCount] = await Promise.all([
@@ -181,17 +171,12 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     sub_events: event.sub_events.map(buildEventSummary),
   };
 
-  return NextResponse.json(body, { status: 200, headers: { "Cache-Control": "no-store" } });
+  return json(body);
 }
 
 export async function PUT(request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -199,38 +184,23 @@ export async function PUT(request: NextRequest, context: RouteContext) {
     where: { id, deleted_at: null },
   });
   if (!existing) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: existing.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON" },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.data;
 
   const parsed = updateEventSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -242,19 +212,16 @@ export async function PUT(request: NextRequest, context: RouteContext) {
       select: { id: true, title: true, parent_id: true },
     });
     if (!parent) {
-      return NextResponse.json(
-        { error: "Parent event not found" },
-        { status: 400, headers: { "Cache-Control": "no-store" } },
-      );
+      return json({ error: "Parent event not found" }, { status: 400 });
     }
     if (parent.parent_id !== null) {
-      return NextResponse.json(
+      return json(
         {
           error: "DEPTH_LIMIT_EXCEEDED",
           message: "Cannot nest events more than one level deep",
           parent_title: parent.title,
         },
-        { status: 400, headers: { "Cache-Control": "no-store" } },
+        { status: 400 },
       );
     }
   }
@@ -265,9 +232,9 @@ export async function PUT(request: NextRequest, context: RouteContext) {
       where: { id: data.event_type_id, project_id: existing.project_id },
     });
     if (!eventType) {
-      return NextResponse.json(
+      return json(
         { error: "Invalid event_type_id: type does not belong to this project" },
-        { status: 400, headers: { "Cache-Control": "no-store" } },
+        { status: 400 },
       );
     }
   }
@@ -373,17 +340,12 @@ export async function PUT(request: NextRequest, context: RouteContext) {
     sub_events: updated.sub_events.map(buildEventSummary),
   };
 
-  return NextResponse.json(responseBody, { status: 200, headers: { "Cache-Control": "no-store" } });
+  return json(responseBody);
 }
 
 export async function DELETE(_request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -391,20 +353,14 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     where: { id, deleted_at: null },
   });
   if (!event) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: event.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   // Check if event has active sub-events
@@ -412,13 +368,13 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     where: { parent_id: id, deleted_at: null },
   });
   if (subEventCount > 0) {
-    return NextResponse.json(
+    return json(
       {
         error: "HAS_SUB_EVENTS",
         message: "Cannot delete an event that has active sub-events",
         count: subEventCount,
       },
-      { status: 409, headers: { "Cache-Control": "no-store" } },
+      { status: 409 },
     );
   }
 
@@ -429,8 +385,5 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
 
   await cache.invalidateByPrefix(`event-list:${event.project_id}:`);
 
-  return NextResponse.json(
-    { deleted: true },
-    { status: 200, headers: { "Cache-Control": "no-store" } },
-  );
+  return json({ deleted: true });
 }

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -200,7 +200,7 @@ export async function PUT(request: NextRequest, context: RouteContext) {
 
   const parsed = updateEventSchema.safeParse(body);
   if (!parsed.success) {
-    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
+    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -212,17 +212,13 @@ export async function PUT(request: NextRequest, context: RouteContext) {
       select: { id: true, title: true, parent_id: true },
     });
     if (!parent) {
-      return json({ error: "Parent event not found" }, { status: 400 });
+      return jsonError(400, "INVALID_REFERENCE", { message: "Parent event not found" });
     }
     if (parent.parent_id !== null) {
-      return json(
-        {
-          error: "DEPTH_LIMIT_EXCEEDED",
-          message: "Cannot nest events more than one level deep",
-          parent_title: parent.title,
-        },
-        { status: 400 },
-      );
+      return jsonError(400, "DEPTH_LIMIT_EXCEEDED", {
+        message: "Cannot nest events more than one level deep",
+        details: { parent_title: parent.title },
+      });
     }
   }
 
@@ -232,10 +228,9 @@ export async function PUT(request: NextRequest, context: RouteContext) {
       where: { id: data.event_type_id, project_id: existing.project_id },
     });
     if (!eventType) {
-      return json(
-        { error: "Invalid event_type_id: type does not belong to this project" },
-        { status: 400 },
-      );
+      return jsonError(400, "INVALID_REFERENCE", {
+        message: "Invalid event_type_id: type does not belong to this project",
+      });
     }
   }
 
@@ -368,14 +363,10 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     where: { parent_id: id, deleted_at: null },
   });
   if (subEventCount > 0) {
-    return json(
-      {
-        error: "HAS_SUB_EVENTS",
-        message: "Cannot delete an event that has active sub-events",
-        count: subEventCount,
-      },
-      { status: 409 },
-    );
+    return jsonError(409, "HAS_SUB_EVENTS", {
+      message: "Cannot delete an event that has active sub-events",
+      details: { count: subEventCount },
+    });
   }
 
   await prisma.event.update({

--- a/src/app/api/events/bulk/route.test.ts
+++ b/src/app/api/events/bulk/route.test.ts
@@ -111,7 +111,7 @@ describe("POST /api/events/bulk", () => {
     const res = await POST(req);
 
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Validation failed");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("VALIDATION_FAILED");
   });
 });

--- a/src/app/api/events/bulk/route.test.ts
+++ b/src/app/api/events/bulk/route.test.ts
@@ -7,8 +7,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockRequireUser = vi.fn();
 const mockEventFindMany = vi.fn();
-const mockEventCount = vi.fn();
-const mockEventUpdate = vi.fn();
+const mockEventGroupBy = vi.fn();
+const mockEventUpdateMany = vi.fn();
 const mockUserProjectFindFirst = vi.fn();
 const mockCacheInvalidate = vi.fn();
 
@@ -20,8 +20,8 @@ vi.mock("@/lib/db", () => ({
   prisma: {
     event: {
       findMany: mockEventFindMany,
-      count: mockEventCount,
-      update: mockEventUpdate,
+      groupBy: mockEventGroupBy,
+      updateMany: mockEventUpdateMany,
     },
     userProject: {
       findFirst: mockUserProjectFindFirst,
@@ -60,22 +60,19 @@ describe("POST /api/events/bulk", () => {
     mockRequireUser.mockResolvedValue({ id: "user-1", projectId: "proj-1" });
     mockUserProjectFindFirst.mockResolvedValue({ id: "mem-1" });
     mockCacheInvalidate.mockResolvedValue(undefined);
-    mockEventUpdate.mockResolvedValue({});
+    mockEventGroupBy.mockResolvedValue([]);
+    mockEventUpdateMany.mockResolvedValue({ count: 0 });
   });
 
   it("skips events with sub-events and deletes the rest, returning skipped list", async () => {
     // Two events: evt-1 has sub-events (skip), evt-2 has none (delete)
-    mockEventFindMany.mockResolvedValue([
-      { id: "evt-1", project_id: "proj-1" },
-      { id: "evt-2", project_id: "proj-1" },
-    ]);
+    mockEventFindMany.mockResolvedValue([{ id: "evt-1" }, { id: "evt-2" }]);
 
-    // evt-1 has 2 sub-events; evt-2 has 0
-    mockEventCount
-      .mockResolvedValueOnce(2) // evt-1
-      .mockResolvedValueOnce(0); // evt-2
+    // One groupBy replaces the per-event counts: only evt-1 has sub-events.
+    mockEventGroupBy.mockResolvedValue([{ parent_id: "evt-1", _count: { _all: 2 } }]);
+    mockEventUpdateMany.mockResolvedValue({ count: 1 });
 
-    const req = makeRequest({ ids: ["evt-1", "evt-2"], action: "delete" });
+    const req = makeRequest({ action: "delete", ids: ["evt-1", "evt-2"], project_id: "proj-1" });
     const res = await POST(req);
 
     expect(res.status).toBe(200);
@@ -87,17 +84,19 @@ describe("POST /api/events/bulk", () => {
     expect(body.skipped).toHaveLength(1);
     expect(body.skipped[0]).toEqual({ id: "evt-1", reason: "HAS_SUB_EVENTS" });
 
-    // Verify only evt-2 was soft-deleted
-    expect(mockEventUpdate).toHaveBeenCalledOnce();
-    expect(mockEventUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { id: "evt-2" } }),
+    // Only evt-2 is deleted, and in a single updateMany rather than N updates.
+    expect(mockEventUpdateMany).toHaveBeenCalledOnce();
+    expect(mockEventUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: { in: ["evt-2"] }, project_id: "proj-1" }),
+      }),
     );
   });
 
   it("returns 200 with deleted:0 when no events are found", async () => {
     mockEventFindMany.mockResolvedValue([]);
 
-    const req = makeRequest({ ids: ["nonexistent-id"], action: "delete" });
+    const req = makeRequest({ action: "delete", ids: ["nonexistent-id"], project_id: "proj-1" });
     const res = await POST(req);
 
     expect(res.status).toBe(200);
@@ -107,7 +106,7 @@ describe("POST /api/events/bulk", () => {
   });
 
   it("returns 400 when ids array is empty", async () => {
-    const req = makeRequest({ ids: [], action: "delete" });
+    const req = makeRequest({ action: "delete", ids: [], project_id: "proj-1" });
     const res = await POST(req);
 
     expect(res.status).toBe(400);

--- a/src/app/api/events/bulk/route.ts
+++ b/src/app/api/events/bulk/route.ts
@@ -1,6 +1,7 @@
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
+import { json, jsonError, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { prisma } from "@/lib/db";
@@ -12,29 +13,15 @@ const bulkEventSchema = z.object({
 
 export async function POST(request: NextRequest) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON" },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.data;
 
   const parsed = bulkEventSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
   }
 
   const { ids } = parsed.data;
@@ -46,10 +33,7 @@ export async function POST(request: NextRequest) {
   });
 
   if (events.length === 0) {
-    return NextResponse.json(
-      { deleted: 0, skipped: [] },
-      { status: 200, headers: { "Cache-Control": "no-store" } },
-    );
+    return json({ deleted: 0, skipped: [] });
   }
 
   // Verify membership for all projects
@@ -59,10 +43,7 @@ export async function POST(request: NextRequest) {
       where: { user_id: user.id, project_id: projectId, role: { in: ["OWNER", "EDITOR"] } },
     });
     if (!membership) {
-      return NextResponse.json(
-        { error: "Forbidden" },
-        { status: 403, headers: { "Cache-Control": "no-store" } },
-      );
+      return json({ error: "Forbidden" }, { status: 403 });
     }
   }
 
@@ -89,8 +70,5 @@ export async function POST(request: NextRequest) {
     await cache.invalidateByPrefix(`event-list:${projectId}:`);
   }
 
-  return NextResponse.json(
-    { deleted, skipped },
-    { status: 200, headers: { "Cache-Control": "no-store" } },
-  );
+  return json({ deleted, skipped });
 }

--- a/src/app/api/events/bulk/route.ts
+++ b/src/app/api/events/bulk/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: NextRequest) {
 
   const parsed = bulkEventSchema.safeParse(body);
   if (!parsed.success) {
-    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
+    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
   }
 
   const { ids } = parsed.data;
@@ -43,7 +43,7 @@ export async function POST(request: NextRequest) {
       where: { user_id: user.id, project_id: projectId, role: { in: ["OWNER", "EDITOR"] } },
     });
     if (!membership) {
-      return json({ error: "Forbidden" }, { status: 403 });
+      return jsonError(403, "FORBIDDEN");
     }
   }
 

--- a/src/app/api/events/bulk/route.ts
+++ b/src/app/api/events/bulk/route.ts
@@ -1,15 +1,18 @@
 import { type NextRequest } from "next/server";
-import { z } from "zod";
 
-import { json, jsonError, parseJsonBody, unauthorized } from "@/lib/api";
+import {
+  WRITE_ROLES,
+  forbidden,
+  json,
+  parseJsonBody,
+  requireProjectMembership,
+  unauthorized,
+  validateBody,
+} from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { prisma } from "@/lib/db";
-
-const bulkEventSchema = z.object({
-  ids: z.array(z.string()).min(1).max(500),
-  action: z.literal("delete"),
-});
+import { type BulkDeleteResult, type BulkSkipped, bulkDeleteSchema } from "@/lib/schemas/bulk";
 
 export async function POST(request: NextRequest) {
   const user = await requireUser();
@@ -17,58 +20,55 @@ export async function POST(request: NextRequest) {
 
   const parsedBody = await parseJsonBody(request);
   if (!parsedBody.ok) return parsedBody.response;
-  const body = parsedBody.data;
 
-  const parsed = bulkEventSchema.safeParse(body);
-  if (!parsed.success) {
-    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
+  const parsed = validateBody(bulkDeleteSchema, parsedBody.data);
+  if (!parsed.ok) return parsed.response;
+
+  const { ids, project_id } = parsed.data;
+
+  if (!(await requireProjectMembership(user.id, project_id, WRITE_ROLES))) {
+    return forbidden();
   }
 
-  const { ids } = parsed.data;
-
-  // Fetch all requested events (non-deleted)
+  // Scoped to the caller's project, so a request can never span projects.
   const events = await prisma.event.findMany({
-    where: { id: { in: ids }, deleted_at: null },
-    select: { id: true, project_id: true },
+    where: { id: { in: ids }, project_id, deleted_at: null },
+    select: { id: true },
   });
 
   if (events.length === 0) {
-    return json({ deleted: 0, skipped: [] });
+    return json<BulkDeleteResult>({ deleted: 0, skipped: [] });
   }
 
-  // Verify membership for all projects
-  const projectIds = [...new Set(events.map((e) => e.project_id))];
-  for (const projectId of projectIds) {
-    const membership = await prisma.userProject.findFirst({
-      where: { user_id: user.id, project_id: projectId, role: { in: ["OWNER", "EDITOR"] } },
-    });
-    if (!membership) {
-      return jsonError(403, "FORBIDDEN");
-    }
-  }
+  const eventIds = events.map((e) => e.id);
 
-  let deleted = 0;
-  const skipped: { id: string; reason: "HAS_SUB_EVENTS" }[] = [];
+  // One groupBy instead of a count per event — this was up to 500 sequential
+  // queries followed by 500 sequential updates (audit A-M6).
+  const subEventCounts = await prisma.event.groupBy({
+    by: ["parent_id"],
+    where: { parent_id: { in: eventIds }, deleted_at: null },
+    _count: { _all: true },
+  });
+  const hasSubEvents = new Set(
+    subEventCounts.map((row) => row.parent_id).filter((id): id is string => id !== null),
+  );
 
-  for (const event of events) {
-    const subEventCount = await prisma.event.count({
-      where: { parent_id: event.id, deleted_at: null },
-    });
+  const skipped: BulkSkipped[] = eventIds
+    .filter((id) => hasSubEvents.has(id))
+    .map((id) => ({ id, reason: "HAS_SUB_EVENTS" }));
+  const deletableIds = eventIds.filter((id) => !hasSubEvents.has(id));
 
-    if (subEventCount > 0) {
-      skipped.push({ id: event.id, reason: "HAS_SUB_EVENTS" });
-    } else {
-      await prisma.event.update({
-        where: { id: event.id },
-        data: { deleted_at: new Date() },
-      });
-      deleted += 1;
-    }
-  }
+  // Single transactional updateMany: a crash can no longer commit a partial
+  // delete with no report of what was actually removed.
+  const result =
+    deletableIds.length > 0
+      ? await prisma.event.updateMany({
+          where: { id: { in: deletableIds }, project_id, deleted_at: null },
+          data: { deleted_at: new Date() },
+        })
+      : { count: 0 };
 
-  for (const projectId of projectIds) {
-    await cache.invalidateByPrefix(`event-list:${projectId}:`);
-  }
+  await cache.invalidateByPrefix(`event-list:${project_id}:`);
 
-  return json({ deleted, skipped });
+  return json<BulkDeleteResult>({ deleted: result.count, skipped });
 }

--- a/src/app/api/events/route.test.ts
+++ b/src/app/api/events/route.test.ts
@@ -250,8 +250,8 @@ describe("POST /api/events", () => {
     const res = await POST(req);
 
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Validation failed");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("VALIDATION_FAILED");
   });
 
   it("returns 400 when start_month provided without start_year", async () => {
@@ -268,8 +268,8 @@ describe("POST /api/events", () => {
     const res = await POST(req);
 
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Validation failed");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("VALIDATION_FAILED");
   });
 
   it("returns 400 DEPTH_LIMIT_EXCEEDED when parent is itself a sub-event", async () => {
@@ -294,10 +294,9 @@ describe("POST /api/events", () => {
 
     expect(res.status).toBe(400);
     const body = (await res.json()) as {
-      error: string;
-      parent_title: string;
+      error: { code: string; details: { parent_title: string } };
     };
-    expect(body.error).toBe("DEPTH_LIMIT_EXCEEDED");
-    expect(body.parent_title).toBe("Verdun");
+    expect(body.error.code).toBe("DEPTH_LIMIT_EXCEEDED");
+    expect(body.error.details.parent_title).toBe("Verdun");
   });
 });

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,7 +1,8 @@
 import { type Prisma } from "@prisma/client";
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
+import { forbidden, json, jsonError, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { db, prisma } from "@/lib/db";
@@ -109,19 +110,14 @@ function buildEventSummary(event: {
 
 export async function GET(request: NextRequest) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { searchParams } = request.nextUrl;
   const parsed = listQuerySchema.safeParse(Object.fromEntries(searchParams));
   if (!parsed.success) {
-    return NextResponse.json(
+    return json(
       { error: "Invalid query params", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
+      { status: 400 },
     );
   }
 
@@ -130,20 +126,14 @@ export async function GET(request: NextRequest) {
   // TODO: Epic 3.1 — replace with project switcher
   const projectId = parsed.data.projectId ?? user.projectId;
   if (!projectId) {
-    return NextResponse.json(
-      { error: "No project" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return json({ error: "No project" }, { status: 403 });
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: projectId },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   const typeIds = parsed.data.typeIds ? parsed.data.typeIds.split(",").filter(Boolean) : [];
@@ -152,7 +142,7 @@ export async function GET(request: NextRequest) {
   const cacheKey = `event-list:${projectId}:${page}:${pageSize}:${search ?? ""}:${sort}:${order}:${sortedTypeIds}:${fromYear ?? ""}:${toYear ?? ""}:${topLevelOnly}`;
   const cached = await cache.get(cacheKey);
   if (cached) {
-    return NextResponse.json(cached, { status: 200, headers: { "Cache-Control": "no-store" } });
+    return json(cached);
   }
 
   const where: Prisma.EventWhereInput = {
@@ -211,34 +201,20 @@ export async function GET(request: NextRequest) {
 
   await cache.set(cacheKey, body, 60);
 
-  return NextResponse.json(body, { status: 200, headers: { "Cache-Control": "no-store" } });
+  return json(body);
 }
 
 export async function POST(request: NextRequest) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON" },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.data;
 
   const parsed = createEventSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -248,10 +224,7 @@ export async function POST(request: NextRequest) {
     where: { user_id: user.id, project_id: data.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   // Validate parent depth limit
@@ -261,19 +234,16 @@ export async function POST(request: NextRequest) {
       select: { id: true, title: true, parent_id: true },
     });
     if (!parent) {
-      return NextResponse.json(
-        { error: "Parent event not found" },
-        { status: 400, headers: { "Cache-Control": "no-store" } },
-      );
+      return json({ error: "Parent event not found" }, { status: 400 });
     }
     if (parent.parent_id !== null) {
-      return NextResponse.json(
+      return json(
         {
           error: "DEPTH_LIMIT_EXCEEDED",
           message: "Cannot nest events more than one level deep",
           parent_title: parent.title,
         },
-        { status: 400, headers: { "Cache-Control": "no-store" } },
+        { status: 400 },
       );
     }
   }
@@ -284,9 +254,9 @@ export async function POST(request: NextRequest) {
       where: { id: data.event_type_id, project_id: data.project_id },
     });
     if (!eventType) {
-      return NextResponse.json(
+      return json(
         { error: "Invalid event_type_id: type does not belong to this project" },
-        { status: 400, headers: { "Cache-Control": "no-store" } },
+        { status: 400 },
       );
     }
   }
@@ -360,5 +330,5 @@ export async function POST(request: NextRequest) {
     sub_events: event.sub_events.map(buildEventSummary),
   };
 
-  return NextResponse.json(responseBody, { status: 201, headers: { "Cache-Control": "no-store" } });
+  return json(responseBody, { status: 201 });
 }

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -115,10 +115,7 @@ export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const parsed = listQuerySchema.safeParse(Object.fromEntries(searchParams));
   if (!parsed.success) {
-    return json(
-      { error: "Invalid query params", details: parsed.error.flatten() },
-      { status: 400 },
-    );
+    return jsonError(400, "INVALID_QUERY_PARAMS", { details: parsed.error.flatten() });
   }
 
   const { page, pageSize, search, sort, order, fromYear, toYear } = parsed.data;
@@ -126,7 +123,7 @@ export async function GET(request: NextRequest) {
   // TODO: Epic 3.1 — replace with project switcher
   const projectId = parsed.data.projectId ?? user.projectId;
   if (!projectId) {
-    return json({ error: "No project" }, { status: 403 });
+    return jsonError(403, "NO_PROJECT");
   }
 
   const membership = await prisma.userProject.findFirst({
@@ -214,7 +211,7 @@ export async function POST(request: NextRequest) {
 
   const parsed = createEventSchema.safeParse(body);
   if (!parsed.success) {
-    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
+    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -234,17 +231,13 @@ export async function POST(request: NextRequest) {
       select: { id: true, title: true, parent_id: true },
     });
     if (!parent) {
-      return json({ error: "Parent event not found" }, { status: 400 });
+      return jsonError(400, "INVALID_REFERENCE", { message: "Parent event not found" });
     }
     if (parent.parent_id !== null) {
-      return json(
-        {
-          error: "DEPTH_LIMIT_EXCEEDED",
-          message: "Cannot nest events more than one level deep",
-          parent_title: parent.title,
-        },
-        { status: 400 },
-      );
+      return jsonError(400, "DEPTH_LIMIT_EXCEEDED", {
+        message: "Cannot nest events more than one level deep",
+        details: { parent_title: parent.title },
+      });
     }
   }
 
@@ -254,10 +247,9 @@ export async function POST(request: NextRequest) {
       where: { id: data.event_type_id, project_id: data.project_id },
     });
     if (!eventType) {
-      return json(
-        { error: "Invalid event_type_id: type does not belong to this project" },
-        { status: 400 },
-      );
+      return jsonError(400, "INVALID_REFERENCE", {
+        message: "Invalid event_type_id: type does not belong to this project",
+      });
     }
   }
 

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -2,7 +2,7 @@ import { type Prisma } from "@prisma/client";
 import { type NextRequest } from "next/server";
 import { z } from "zod";
 
-import { forbidden, json, jsonError, parseJsonBody, unauthorized } from "@/lib/api";
+import { forbidden, json, jsonError, paginated, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { db, prisma } from "@/lib/db";
@@ -186,15 +186,7 @@ export async function GET(request: NextRequest) {
     }),
   ]);
 
-  const body = {
-    data: events.map(buildEventSummary),
-    pagination: {
-      page,
-      pageSize,
-      total,
-      totalPages: Math.ceil(total / pageSize),
-    },
-  };
+  const body = paginated(events.map(buildEventSummary), { page, pageSize, total });
 
   await cache.set(cacheKey, body, 60);
 

--- a/src/app/api/persons/[id]/route.ts
+++ b/src/app/api/persons/[id]/route.ts
@@ -1,7 +1,8 @@
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
 import { logActivity } from "@/lib/activity";
+import { forbidden, json, jsonError, notFoundError, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { db, prisma } from "@/lib/db";
@@ -67,12 +68,7 @@ type RouteContext = { params: Promise<{ id: string }> };
 
 export async function GET(_request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -84,10 +80,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   });
 
   if (!person) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   // Check project membership
@@ -95,10 +88,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     where: { user_id: user.id, project_id: person.project_id },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   const body = {
@@ -127,17 +117,12 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     _count: { relations_from: 0, relations_to: 0 },
   };
 
-  return NextResponse.json(body, { status: 200, headers: { "Cache-Control": "no-store" } });
+  return json(body);
 }
 
 export async function PUT(request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -146,38 +131,23 @@ export async function PUT(request: NextRequest, context: RouteContext) {
     where: { id, deleted_at: null },
   });
   if (!existing) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: existing.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON" },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.data;
 
   const parsed = updatePersonSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -314,17 +284,12 @@ export async function PUT(request: NextRequest, context: RouteContext) {
     _count: updatedPerson._count,
   };
 
-  return NextResponse.json(responseBody, { status: 200, headers: { "Cache-Control": "no-store" } });
+  return json(responseBody);
 }
 
 export async function DELETE(_request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -332,20 +297,14 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     where: { id, deleted_at: null },
   });
   if (!person) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: person.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   await prisma.person.update({
@@ -355,8 +314,5 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
 
   await cache.invalidateByPrefix(`person-list:${person.project_id}:`);
 
-  return NextResponse.json(
-    { deleted: true },
-    { status: 200, headers: { "Cache-Control": "no-store" } },
-  );
+  return json({ deleted: true });
 }

--- a/src/app/api/persons/[id]/route.ts
+++ b/src/app/api/persons/[id]/route.ts
@@ -91,7 +91,7 @@ export async function PUT(request: NextRequest, context: RouteContext) {
 
   const parsed = updatePersonSchema.safeParse(body);
   if (!parsed.success) {
-    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
+    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;

--- a/src/app/api/persons/[id]/route.ts
+++ b/src/app/api/persons/[id]/route.ts
@@ -1,5 +1,4 @@
 import { type NextRequest } from "next/server";
-import { z } from "zod";
 
 import { logActivity } from "@/lib/activity";
 import { forbidden, json, jsonError, notFoundError, parseJsonBody, unauthorized } from "@/lib/api";
@@ -7,62 +6,7 @@ import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { db, prisma } from "@/lib/db";
 import { sanitize } from "@/lib/sanitize";
-
-const updatePersonSchema = z
-  .object({
-    first_name: z.string().optional(),
-    last_name: z.string().optional(),
-    birth_year: z.number().int().min(1).max(2100).optional().nullable(),
-    birth_month: z.number().int().min(1).max(12).optional().nullable(),
-    birth_day: z.number().int().min(1).max(31).optional().nullable(),
-    birth_date_certainty: z.enum(["CERTAIN", "PROBABLE", "POSSIBLE", "UNKNOWN"]).optional(),
-    birth_place: z.string().optional().nullable(),
-    death_year: z.number().int().min(1).max(2100).optional().nullable(),
-    death_month: z.number().int().min(1).max(12).optional().nullable(),
-    death_day: z.number().int().min(1).max(31).optional().nullable(),
-    death_date_certainty: z.enum(["CERTAIN", "PROBABLE", "POSSIBLE", "UNKNOWN"]).optional(),
-    death_place: z.string().optional().nullable(),
-    notes: z.string().optional().nullable(),
-    names: z
-      .array(
-        z.object({
-          name: z.string().min(1),
-          language: z.string().optional().nullable(),
-          is_primary: z.boolean().optional(),
-        }),
-      )
-      .optional(),
-  })
-  .superRefine((data, ctx) => {
-    if (data.birth_month && !data.birth_year) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["birth_month"],
-        message: "month_requires_year",
-      });
-    }
-    if (data.birth_day && !data.birth_month) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["birth_day"],
-        message: "day_requires_month",
-      });
-    }
-    if (data.death_month && !data.death_year) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["death_month"],
-        message: "month_requires_year",
-      });
-    }
-    if (data.death_day && !data.death_month) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["death_day"],
-        message: "day_requires_month",
-      });
-    }
-  });
+import { updatePersonSchema } from "@/lib/schemas/person";
 
 type RouteContext = { params: Promise<{ id: string }> };
 

--- a/src/app/api/persons/bulk/route.ts
+++ b/src/app/api/persons/bulk/route.ts
@@ -1,6 +1,7 @@
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
+import { json, jsonError, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { prisma } from "@/lib/db";
@@ -12,29 +13,15 @@ const bulkPersonSchema = z.object({
 
 export async function POST(request: NextRequest) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON" },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.data;
 
   const parsed = bulkPersonSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
   }
 
   const { ids } = parsed.data;
@@ -46,10 +33,7 @@ export async function POST(request: NextRequest) {
   });
 
   if (persons.length === 0) {
-    return NextResponse.json(
-      { deleted: 0 },
-      { status: 200, headers: { "Cache-Control": "no-store" } },
-    );
+    return json({ deleted: 0 });
   }
 
   // All must belong to the same project
@@ -60,10 +44,7 @@ export async function POST(request: NextRequest) {
       where: { user_id: user.id, project_id: projectId, role: { in: ["OWNER", "EDITOR"] } },
     });
     if (!membership) {
-      return NextResponse.json(
-        { error: "Forbidden" },
-        { status: 403, headers: { "Cache-Control": "no-store" } },
-      );
+      return json({ error: "Forbidden" }, { status: 403 });
     }
   }
 
@@ -77,8 +58,5 @@ export async function POST(request: NextRequest) {
     await cache.invalidateByPrefix(`person-list:${projectId}:`);
   }
 
-  return NextResponse.json(
-    { deleted: result.count },
-    { status: 200, headers: { "Cache-Control": "no-store" } },
-  );
+  return json({ deleted: result.count });
 }

--- a/src/app/api/persons/bulk/route.ts
+++ b/src/app/api/persons/bulk/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: NextRequest) {
 
   const parsed = bulkPersonSchema.safeParse(body);
   if (!parsed.success) {
-    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
+    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
   }
 
   const { ids } = parsed.data;
@@ -44,7 +44,7 @@ export async function POST(request: NextRequest) {
       where: { user_id: user.id, project_id: projectId, role: { in: ["OWNER", "EDITOR"] } },
     });
     if (!membership) {
-      return json({ error: "Forbidden" }, { status: 403 });
+      return jsonError(403, "FORBIDDEN");
     }
   }
 

--- a/src/app/api/persons/bulk/route.ts
+++ b/src/app/api/persons/bulk/route.ts
@@ -1,15 +1,18 @@
 import { type NextRequest } from "next/server";
-import { z } from "zod";
 
-import { json, jsonError, parseJsonBody, unauthorized } from "@/lib/api";
+import {
+  WRITE_ROLES,
+  forbidden,
+  json,
+  parseJsonBody,
+  requireProjectMembership,
+  unauthorized,
+  validateBody,
+} from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { prisma } from "@/lib/db";
-
-const bulkPersonSchema = z.object({
-  ids: z.array(z.string()).min(1).max(500),
-  action: z.literal("delete"),
-});
+import { type BulkDeleteResult, bulkDeleteSchema } from "@/lib/schemas/bulk";
 
 export async function POST(request: NextRequest) {
   const user = await requireUser();
@@ -17,46 +20,25 @@ export async function POST(request: NextRequest) {
 
   const parsedBody = await parseJsonBody(request);
   if (!parsedBody.ok) return parsedBody.response;
-  const body = parsedBody.data;
 
-  const parsed = bulkPersonSchema.safeParse(body);
-  if (!parsed.success) {
-    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
+  const parsed = validateBody(bulkDeleteSchema, parsedBody.data);
+  if (!parsed.ok) return parsed.response;
+
+  const { ids, project_id } = parsed.data;
+
+  if (!(await requireProjectMembership(user.id, project_id, WRITE_ROLES))) {
+    return forbidden();
   }
 
-  const { ids } = parsed.data;
-
-  // Verify all persons belong to a project the user has OWNER/EDITOR access to
-  const persons = await prisma.person.findMany({
-    where: { id: { in: ids }, deleted_at: null },
-    select: { id: true, project_id: true },
-  });
-
-  if (persons.length === 0) {
-    return json({ deleted: 0 });
-  }
-
-  // All must belong to the same project
-  const projectIds = [...new Set(persons.map((p) => p.project_id))];
-
-  for (const projectId of projectIds) {
-    const membership = await prisma.userProject.findFirst({
-      where: { user_id: user.id, project_id: projectId, role: { in: ["OWNER", "EDITOR"] } },
-    });
-    if (!membership) {
-      return jsonError(403, "FORBIDDEN");
-    }
-  }
-
-  const foundIds = persons.map((p) => p.id);
+  // Scoped to the caller's project, so a request can never span projects.
   const result = await prisma.person.updateMany({
-    where: { id: { in: foundIds } },
+    where: { id: { in: ids }, project_id, deleted_at: null },
     data: { deleted_at: new Date() },
   });
 
-  for (const projectId of projectIds) {
-    await cache.invalidateByPrefix(`person-list:${projectId}:`);
-  }
+  await cache.invalidateByPrefix(`person-list:${project_id}:`);
 
-  return json({ deleted: result.count });
+  // Persons have no delete-blocking rule, so nothing is ever skipped — the key
+  // is still present so clients never branch on its existence.
+  return json<BulkDeleteResult>({ deleted: result.count, skipped: [] });
 }

--- a/src/app/api/persons/route.test.ts
+++ b/src/app/api/persons/route.test.ts
@@ -119,8 +119,8 @@ describe("GET /api/persons", () => {
     const res = await GET(req);
 
     expect(res.status).toBe(401);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Unauthorized");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("UNAUTHORIZED");
   });
 
   it("returns 403 when the user is not a member of the requested project", async () => {
@@ -220,8 +220,8 @@ describe("POST /api/persons", () => {
     const res = await POST(req);
 
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Validation failed");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("VALIDATION_FAILED");
   });
 
   it("returns 403 when the user is not a member of the target project", async () => {

--- a/src/app/api/persons/route.ts
+++ b/src/app/api/persons/route.ts
@@ -7,6 +7,7 @@ import {
   forbidden,
   json,
   jsonError,
+  paginated,
   parseJsonBody,
   requireProjectMembership,
   unauthorized,
@@ -87,8 +88,8 @@ export async function GET(request: NextRequest) {
     }),
   ]);
 
-  const body = {
-    data: persons.map((p) => ({
+  const body = paginated(
+    persons.map((p) => ({
       id: p.id,
       first_name: p.first_name,
       last_name: p.last_name,
@@ -107,13 +108,8 @@ export async function GET(request: NextRequest) {
         is_primary: n.is_primary,
       })),
     })),
-    pagination: {
-      page,
-      pageSize,
-      total,
-      totalPages: Math.ceil(total / pageSize),
-    },
-  };
+    { page, pageSize, total },
+  );
 
   await cache.set(cacheKey, body, 60);
 

--- a/src/app/api/persons/route.ts
+++ b/src/app/api/persons/route.ts
@@ -34,13 +34,13 @@ export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const parsed = listQuerySchema.safeParse(Object.fromEntries(searchParams));
   if (!parsed.success) {
-    return jsonError(400, "Invalid query params", { details: parsed.error.flatten() });
+    return jsonError(400, "INVALID_QUERY_PARAMS", { details: parsed.error.flatten() });
   }
 
   const { page, pageSize, search, sort, order } = parsed.data;
   // TODO: Epic 3.1 — replace with project switcher
   const projectId = parsed.data.projectId ?? user.projectId;
-  if (!projectId) return jsonError(403, "No project");
+  if (!projectId) return jsonError(403, "NO_PROJECT");
 
   // Must precede the cache lookup: serving cached data before the membership
   // check is exactly how the C1 IDOR leaked cross-tenant rows.

--- a/src/app/api/persons/route.ts
+++ b/src/app/api/persons/route.ts
@@ -1,7 +1,17 @@
 import { type Prisma } from "@prisma/client";
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
+import {
+  WRITE_ROLES,
+  forbidden,
+  json,
+  jsonError,
+  parseJsonBody,
+  requireProjectMembership,
+  unauthorized,
+  validateBody,
+} from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { db, prisma } from "@/lib/db";
@@ -94,47 +104,26 @@ const createPersonSchema = z
 
 export async function GET(request: NextRequest) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { searchParams } = request.nextUrl;
   const parsed = listQuerySchema.safeParse(Object.fromEntries(searchParams));
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Invalid query params", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return jsonError(400, "Invalid query params", { details: parsed.error.flatten() });
   }
 
   const { page, pageSize, search, sort, order } = parsed.data;
   // TODO: Epic 3.1 — replace with project switcher
   const projectId = parsed.data.projectId ?? user.projectId;
-  if (!projectId) {
-    return NextResponse.json(
-      { error: "No project" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!projectId) return jsonError(403, "No project");
 
-  const membership = await prisma.userProject.findFirst({
-    where: { user_id: user.id, project_id: projectId },
-  });
-  if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  // Must precede the cache lookup: serving cached data before the membership
+  // check is exactly how the C1 IDOR leaked cross-tenant rows.
+  if (!(await requireProjectMembership(user.id, projectId))) return forbidden();
 
   const cacheKey = `person-list:${projectId}:${page}:${pageSize}:${search ?? ""}:${sort}:${order}`;
   const cached = await cache.get(cacheKey);
-  if (cached) {
-    return NextResponse.json(cached, { status: 200, headers: { "Cache-Control": "no-store" } });
-  }
+  if (cached) return json(cached);
 
   const where: Prisma.PersonWhereInput = {
     project_id: projectId,
@@ -203,47 +192,23 @@ export async function GET(request: NextRequest) {
 
   await cache.set(cacheKey, body, 60);
 
-  return NextResponse.json(body, { status: 200, headers: { "Cache-Control": "no-store" } });
+  return json(body);
 }
 
 export async function POST(request: NextRequest) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON" },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.response;
 
-  const parsed = createPersonSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsed = validateBody(createPersonSchema, parsedBody.data);
+  if (!parsed.ok) return parsed.response;
 
   const data = parsed.data;
 
-  // Verify user is a member of the project
-  const membership = await prisma.userProject.findFirst({
-    where: { user_id: user.id, project_id: data.project_id, role: { in: ["OWNER", "EDITOR"] } },
-  });
-  if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+  if (!(await requireProjectMembership(user.id, data.project_id, WRITE_ROLES))) {
+    return forbidden();
   }
 
   const createData: Prisma.PersonUncheckedCreateInput = {
@@ -308,5 +273,5 @@ export async function POST(request: NextRequest) {
     _count: { relations_from: 0, relations_to: 0 },
   };
 
-  return NextResponse.json(responseBody, { status: 201, headers: { "Cache-Control": "no-store" } });
+  return json(responseBody, { status: 201 });
 }

--- a/src/app/api/persons/route.ts
+++ b/src/app/api/persons/route.ts
@@ -16,6 +16,7 @@ import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { db, prisma } from "@/lib/db";
 import { sanitize } from "@/lib/sanitize";
+import { createPersonSchema } from "@/lib/schemas/person";
 
 const listQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
@@ -25,82 +26,6 @@ const listQuerySchema = z.object({
   order: z.enum(["asc", "desc"]).default("asc"),
   projectId: z.string().optional(),
 });
-
-const createPersonSchema = z
-  .object({
-    project_id: z.string().min(1),
-    first_name: z.string().optional(),
-    last_name: z.string().optional(),
-    birth_year: z.number().int().min(1).max(2100).optional(),
-    birth_month: z.number().int().min(1).max(12).optional(),
-    birth_day: z.number().int().min(1).max(31).optional(),
-    birth_date_certainty: z.enum(["CERTAIN", "PROBABLE", "POSSIBLE", "UNKNOWN"]).optional(),
-    birth_place: z.string().optional(),
-    death_year: z.number().int().min(1).max(2100).optional(),
-    death_month: z.number().int().min(1).max(12).optional(),
-    death_day: z.number().int().min(1).max(31).optional(),
-    death_date_certainty: z.enum(["CERTAIN", "PROBABLE", "POSSIBLE", "UNKNOWN"]).optional(),
-    death_place: z.string().optional(),
-    notes: z.string().optional(),
-    names: z
-      .array(
-        z.object({
-          name: z.string().min(1),
-          language: z.string().optional(),
-          is_primary: z.boolean().optional(),
-        }),
-      )
-      .optional(),
-  })
-  .superRefine((data, ctx) => {
-    const hasName =
-      (data.first_name && data.first_name.trim().length > 0) ||
-      (data.last_name && data.last_name.trim().length > 0) ||
-      (data.names && data.names.length > 0);
-    if (!hasName) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["first_name"],
-        message: "name_required",
-      });
-    }
-    if (data.birth_month && !data.birth_year) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["birth_month"],
-        message: "month_requires_year",
-      });
-    }
-    if (data.birth_day && !data.birth_month) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["birth_day"],
-        message: "day_requires_month",
-      });
-    }
-    if (data.death_month && !data.death_year) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["death_month"],
-        message: "month_requires_year",
-      });
-    }
-    if (data.death_day && !data.death_month) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["death_day"],
-        message: "day_requires_month",
-      });
-    }
-    const primaryCount = (data.names ?? []).filter((n) => n.is_primary).length;
-    if (primaryCount > 1) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["names"],
-        message: "Only one primary name allowed",
-      });
-    }
-  });
 
 export async function GET(request: NextRequest) {
   const user = await requireUser();

--- a/src/app/api/property-evidence/[id]/route.ts
+++ b/src/app/api/property-evidence/[id]/route.ts
@@ -1,6 +1,7 @@
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 
 import { logActivity } from "@/lib/activity";
+import { forbidden, json, notFoundError, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { prisma } from "@/lib/db";
 
@@ -8,12 +9,7 @@ type RouteContext = { params: Promise<{ id: string }> };
 
 export async function DELETE(_request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -30,20 +26,14 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     },
   });
   if (!record) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: record.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   await prisma.propertyEvidence.delete({ where: { id } });
@@ -58,8 +48,5 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     old_value: { source_id: record.source_id },
   }).catch(console.error);
 
-  return NextResponse.json(
-    { deleted: true },
-    { status: 200, headers: { "Cache-Control": "no-store" } },
-  );
+  return json({ deleted: true });
 }

--- a/src/app/api/property-evidence/route.test.ts
+++ b/src/app/api/property-evidence/route.test.ts
@@ -165,9 +165,9 @@ describe("POST /api/property-evidence", () => {
     );
 
     expect(res.status).toBe(422);
-    const body = (await res.json()) as { error: string; allowed: string[] };
-    expect(body.error).toBe("INVALID_PROPERTY");
-    expect(Array.isArray(body.allowed)).toBe(true);
+    const body = (await res.json()) as { error: { code: string; details: { allowed: string[] } } };
+    expect(body.error.code).toBe("INVALID_PROPERTY");
+    expect(Array.isArray(body.error.details.allowed)).toBe(true);
   });
 
   it("returns 404 when entity does not exist", async () => {

--- a/src/app/api/property-evidence/route.ts
+++ b/src/app/api/property-evidence/route.ts
@@ -1,8 +1,9 @@
 import { type Prisma } from "@prisma/client";
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
 import { logActivity } from "@/lib/activity";
+import { forbidden, json, jsonError, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { prisma } from "@/lib/db";
 import { validateEntityExists } from "@/lib/entity-validation";
@@ -63,19 +64,14 @@ const createPropertyEvidenceSchema = z.object({
 
 export async function GET(request: NextRequest) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { searchParams } = request.nextUrl;
   const parsed = listQuerySchema.safeParse(Object.fromEntries(searchParams));
   if (!parsed.success) {
-    return NextResponse.json(
+    return json(
       { error: "Invalid query params", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
+      { status: 400 },
     );
   }
 
@@ -86,10 +82,7 @@ export async function GET(request: NextRequest) {
     where: { user_id: user.id, project_id: projectId },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   const where: Prisma.PropertyEvidenceWhereInput = { project_id: projectId };
@@ -121,34 +114,20 @@ export async function GET(request: NextRequest) {
     created_at: r.created_at.toISOString(),
   }));
 
-  return NextResponse.json({ data }, { status: 200, headers: { "Cache-Control": "no-store" } });
+  return json({ data });
 }
 
 export async function POST(request: NextRequest) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON" },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.data;
 
   const parsed = createPropertyEvidenceSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -158,28 +137,23 @@ export async function POST(request: NextRequest) {
     where: { user_id: user.id, project_id: data.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   // Validate property against allowed list
   const allowed = ALLOWED_PROPERTIES[data.entity_type] ?? [];
   if (!allowed.includes(data.property)) {
-    return NextResponse.json(
-      { error: "INVALID_PROPERTY", allowed },
-      { status: 422, headers: { "Cache-Control": "no-store" } },
-    );
+    return json({ error: "INVALID_PROPERTY", allowed }, { status: 422 });
   }
 
   // Validate entity exists
-  const entityExists = await validateEntityExists(data.entity_type, data.entity_id, data.project_id);
+  const entityExists = await validateEntityExists(
+    data.entity_type,
+    data.entity_id,
+    data.project_id,
+  );
   if (!entityExists) {
-    return NextResponse.json(
-      { error: "Entity not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return json({ error: "Entity not found" }, { status: 404 });
   }
 
   // Validate source belongs to same project
@@ -188,10 +162,7 @@ export async function POST(request: NextRequest) {
     select: { id: true },
   });
   if (!source) {
-    return NextResponse.json(
-      { error: "Source does not belong to this project" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return json({ error: "Source does not belong to this project" }, { status: 403 });
   }
 
   const record = await prisma.propertyEvidence.create({
@@ -222,7 +193,7 @@ export async function POST(request: NextRequest) {
     new_value: { source_id: data.source_id, confidence: record.confidence },
   }).catch(console.error);
 
-  return NextResponse.json(
+  return json(
     {
       id: record.id,
       project_id: record.project_id,
@@ -238,6 +209,6 @@ export async function POST(request: NextRequest) {
       confidence: record.confidence,
       created_at: record.created_at.toISOString(),
     },
-    { status: 201, headers: { "Cache-Control": "no-store" } },
+    { status: 201 },
   );
 }

--- a/src/app/api/property-evidence/route.ts
+++ b/src/app/api/property-evidence/route.ts
@@ -69,10 +69,7 @@ export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const parsed = listQuerySchema.safeParse(Object.fromEntries(searchParams));
   if (!parsed.success) {
-    return json(
-      { error: "Invalid query params", details: parsed.error.flatten() },
-      { status: 400 },
-    );
+    return jsonError(400, "INVALID_QUERY_PARAMS", { details: parsed.error.flatten() });
   }
 
   const { projectId, entityType, entityId, property } = parsed.data;
@@ -127,7 +124,7 @@ export async function POST(request: NextRequest) {
 
   const parsed = createPropertyEvidenceSchema.safeParse(body);
   if (!parsed.success) {
-    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
+    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -143,7 +140,7 @@ export async function POST(request: NextRequest) {
   // Validate property against allowed list
   const allowed = ALLOWED_PROPERTIES[data.entity_type] ?? [];
   if (!allowed.includes(data.property)) {
-    return json({ error: "INVALID_PROPERTY", allowed }, { status: 422 });
+    return jsonError(422, "INVALID_PROPERTY", { details: { allowed } });
   }
 
   // Validate entity exists
@@ -153,7 +150,7 @@ export async function POST(request: NextRequest) {
     data.project_id,
   );
   if (!entityExists) {
-    return json({ error: "Entity not found" }, { status: 404 });
+    return jsonError(404, "ENTITY_NOT_FOUND");
   }
 
   // Validate source belongs to same project
@@ -162,7 +159,9 @@ export async function POST(request: NextRequest) {
     select: { id: true },
   });
   if (!source) {
-    return json({ error: "Source does not belong to this project" }, { status: 403 });
+    return jsonError(403, "INVALID_REFERENCE", {
+      message: "Source does not belong to this project",
+    });
   }
 
   const record = await prisma.propertyEvidence.create({

--- a/src/app/api/relation-types/[id]/route.test.ts
+++ b/src/app/api/relation-types/[id]/route.test.ts
@@ -147,9 +147,9 @@ describe("DELETE /api/relation-types/[id]", () => {
     mockRelationCount.mockResolvedValue(5);
     const res = await DELETE(makeDeleteRequest("rt-1"), makeCtx("rt-1"));
     expect(res.status).toBe(409);
-    const body = (await res.json()) as { error: string; count: number };
-    expect(body.error).toBe("IN_USE");
-    expect(body.count).toBe(5);
+    const body = (await res.json()) as { error: { code: string; details: { count: number } } };
+    expect(body.error.code).toBe("IN_USE");
+    expect(body.error.details.count).toBe(5);
   });
 
   it("returns 409 IN_USE_BY_DELETED when only soft-deleted relations reference it", async () => {
@@ -157,9 +157,9 @@ describe("DELETE /api/relation-types/[id]", () => {
     mockRelationCount.mockResolvedValueOnce(0).mockResolvedValueOnce(3);
     const res = await DELETE(makeDeleteRequest("rt-1"), makeCtx("rt-1"));
     expect(res.status).toBe(409);
-    const body = (await res.json()) as { error: string; count: number };
-    expect(body.error).toBe("IN_USE_BY_DELETED");
-    expect(body.count).toBe(3);
+    const body = (await res.json()) as { error: { code: string; details: { count: number } } };
+    expect(body.error.code).toBe("IN_USE_BY_DELETED");
+    expect(body.error.details.count).toBe(3);
     expect(mockRelationTypeDelete).not.toHaveBeenCalled();
   });
 
@@ -172,8 +172,8 @@ describe("DELETE /api/relation-types/[id]", () => {
     );
     const res = await DELETE(makeDeleteRequest("rt-1"), makeCtx("rt-1"));
     expect(res.status).toBe(409);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("IN_USE");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("IN_USE");
   });
 
   it("returns 404 when relation type not found", async () => {

--- a/src/app/api/relation-types/[id]/route.ts
+++ b/src/app/api/relation-types/[id]/route.ts
@@ -1,7 +1,8 @@
 import { Prisma } from "@prisma/client";
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
+import { forbidden, json, jsonError, notFoundError, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { prisma } from "@/lib/db";
@@ -27,12 +28,7 @@ type RouteContext = { params: Promise<{ id: string }> };
 
 export async function PUT(request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -40,38 +36,23 @@ export async function PUT(request: NextRequest, context: RouteContext) {
     where: { id },
   });
   if (!existing) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: existing.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON" },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.data;
 
   const parsed = updateRelationTypeSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -101,32 +82,24 @@ export async function PUT(request: NextRequest, context: RouteContext) {
   // invalidate so the writer doesn't immediately read back their own stale edit.
   await cache.invalidateByPrefix(`relation-list:${existing.project_id}:`);
 
-  return NextResponse.json(
-    {
-      id: updated.id,
-      name: updated.name,
-      inverse_name: updated.inverse_name,
-      description: updated.description,
-      color: updated.color,
-      icon: updated.icon,
-      valid_from_types: updated.valid_from_types,
-      valid_to_types: updated.valid_to_types,
-      created_at: updated.created_at.toISOString(),
-      updated_at: updated.updated_at.toISOString(),
-      _count: { relations: updated._count.relations },
-    },
-    { status: 200, headers: { "Cache-Control": "no-store" } },
-  );
+  return json({
+    id: updated.id,
+    name: updated.name,
+    inverse_name: updated.inverse_name,
+    description: updated.description,
+    color: updated.color,
+    icon: updated.icon,
+    valid_from_types: updated.valid_from_types,
+    valid_to_types: updated.valid_to_types,
+    created_at: updated.created_at.toISOString(),
+    updated_at: updated.updated_at.toISOString(),
+    _count: { relations: updated._count.relations },
+  });
 }
 
 export async function DELETE(_request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -134,20 +107,14 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     where: { id },
   });
   if (!existing) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: existing.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   // Check if any non-deleted relations use this type
@@ -155,10 +122,7 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     where: { relation_type_id: id, deleted_at: null },
   });
   if (relationCount > 0) {
-    return NextResponse.json(
-      { error: "IN_USE", count: relationCount },
-      { status: 409, headers: { "Cache-Control": "no-store" } },
-    );
+    return json({ error: "IN_USE", count: relationCount }, { status: 409 });
   }
 
   // Soft-deleted relations still hold the FK (onDelete: Restrict), so a hard
@@ -167,26 +131,17 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     where: { relation_type_id: id, deleted_at: { not: null } },
   });
   if (softDeletedCount > 0) {
-    return NextResponse.json(
-      { error: "IN_USE_BY_DELETED", count: softDeletedCount },
-      { status: 409, headers: { "Cache-Control": "no-store" } },
-    );
+    return json({ error: "IN_USE_BY_DELETED", count: softDeletedCount }, { status: 409 });
   }
 
   try {
     await prisma.relationType.delete({ where: { id } });
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2003") {
-      return NextResponse.json(
-        { error: "IN_USE" },
-        { status: 409, headers: { "Cache-Control": "no-store" } },
-      );
+      return json({ error: "IN_USE" }, { status: 409 });
     }
     throw error;
   }
 
-  return NextResponse.json(
-    { deleted: true },
-    { status: 200, headers: { "Cache-Control": "no-store" } },
-  );
+  return json({ deleted: true });
 }

--- a/src/app/api/relation-types/[id]/route.ts
+++ b/src/app/api/relation-types/[id]/route.ts
@@ -52,7 +52,7 @@ export async function PUT(request: NextRequest, context: RouteContext) {
 
   const parsed = updateRelationTypeSchema.safeParse(body);
   if (!parsed.success) {
-    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
+    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -122,7 +122,7 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     where: { relation_type_id: id, deleted_at: null },
   });
   if (relationCount > 0) {
-    return json({ error: "IN_USE", count: relationCount }, { status: 409 });
+    return jsonError(409, "IN_USE", { details: { count: relationCount } });
   }
 
   // Soft-deleted relations still hold the FK (onDelete: Restrict), so a hard
@@ -131,14 +131,14 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     where: { relation_type_id: id, deleted_at: { not: null } },
   });
   if (softDeletedCount > 0) {
-    return json({ error: "IN_USE_BY_DELETED", count: softDeletedCount }, { status: 409 });
+    return jsonError(409, "IN_USE_BY_DELETED", { details: { count: softDeletedCount } });
   }
 
   try {
     await prisma.relationType.delete({ where: { id } });
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2003") {
-      return json({ error: "IN_USE" }, { status: 409 });
+      return jsonError(409, "IN_USE");
     }
     throw error;
   }

--- a/src/app/api/relation-types/route.test.ts
+++ b/src/app/api/relation-types/route.test.ts
@@ -146,8 +146,8 @@ describe("POST /api/relation-types", () => {
       }),
     );
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Validation failed");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("VALIDATION_FAILED");
   });
 
   it("returns 400 when color is not a valid hex", async () => {

--- a/src/app/api/relation-types/route.ts
+++ b/src/app/api/relation-types/route.ts
@@ -1,6 +1,7 @@
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
+import { forbidden, json, jsonError, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { prisma } from "@/lib/db";
 import { sanitize } from "@/lib/sanitize";
@@ -23,20 +24,12 @@ const createRelationTypeSchema = z.object({
 
 export async function GET(request: NextRequest) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { searchParams } = request.nextUrl;
   const projectId = searchParams.get("projectId") ?? user.projectId;
   if (!projectId) {
-    return NextResponse.json(
-      { error: "No project" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return json({ error: "No project" }, { status: 403 });
   }
 
   // Verify project membership
@@ -44,10 +37,7 @@ export async function GET(request: NextRequest) {
     where: { user_id: user.id, project_id: projectId },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   const relationTypes = await prisma.relationType.findMany({
@@ -74,34 +64,20 @@ export async function GET(request: NextRequest) {
     _count: { relations: rt._count.relations },
   }));
 
-  return NextResponse.json({ data }, { status: 200, headers: { "Cache-Control": "no-store" } });
+  return json({ data });
 }
 
 export async function POST(request: NextRequest) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON" },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.data;
 
   const parsed = createRelationTypeSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -111,10 +87,7 @@ export async function POST(request: NextRequest) {
     where: { user_id: user.id, project_id: data.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   const relationType = await prisma.relationType.create({
@@ -130,7 +103,7 @@ export async function POST(request: NextRequest) {
     },
   });
 
-  return NextResponse.json(
+  return json(
     {
       id: relationType.id,
       name: relationType.name,
@@ -144,6 +117,6 @@ export async function POST(request: NextRequest) {
       updated_at: relationType.updated_at.toISOString(),
       _count: { relations: 0 },
     },
-    { status: 201, headers: { "Cache-Control": "no-store" } },
+    { status: 201 },
   );
 }

--- a/src/app/api/relation-types/route.ts
+++ b/src/app/api/relation-types/route.ts
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const projectId = searchParams.get("projectId") ?? user.projectId;
   if (!projectId) {
-    return json({ error: "No project" }, { status: 403 });
+    return jsonError(403, "NO_PROJECT");
   }
 
   // Verify project membership
@@ -77,7 +77,7 @@ export async function POST(request: NextRequest) {
 
   const parsed = createRelationTypeSchema.safeParse(body);
   if (!parsed.success) {
-    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
+    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;

--- a/src/app/api/relations/[id]/evidence/[evidenceId]/route.ts
+++ b/src/app/api/relations/[id]/evidence/[evidenceId]/route.ts
@@ -1,5 +1,6 @@
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 
+import { forbidden, json, notFoundError, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { db, prisma } from "@/lib/db";
@@ -8,12 +9,7 @@ type RouteContext = { params: Promise<{ id: string; evidenceId: string }> };
 
 export async function DELETE(_request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id, evidenceId } = await context.params;
 
@@ -23,10 +19,7 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     select: { id: true, relation_id: true },
   });
   if (!evidence) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   // Get the relation to check project membership (use db for soft-delete exclusion)
@@ -35,20 +28,14 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     select: { project_id: true },
   });
   if (!relation) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: relation.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   await prisma.relationEvidence.delete({ where: { id: evidenceId } });
@@ -56,8 +43,5 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
   // The relation list embeds evidence_count — it goes stale on every removal.
   await cache.invalidateByPrefix(`relation-list:${relation.project_id}:`);
 
-  return NextResponse.json(
-    { deleted: true },
-    { status: 200, headers: { "Cache-Control": "no-store" } },
-  );
+  return json({ deleted: true });
 }

--- a/src/app/api/relations/[id]/evidence/route.test.ts
+++ b/src/app/api/relations/[id]/evidence/route.test.ts
@@ -156,8 +156,8 @@ describe("POST /api/relations/[id]/evidence", () => {
     );
 
     expect(res.status).toBe(409);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("DUPLICATE_EVIDENCE");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("DUPLICATE_EVIDENCE");
   });
 
   it("returns 403 when source not in project", async () => {

--- a/src/app/api/relations/[id]/evidence/route.ts
+++ b/src/app/api/relations/[id]/evidence/route.ts
@@ -1,7 +1,8 @@
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
 import { logActivity } from "@/lib/activity";
+import { forbidden, json, jsonError, notFoundError, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { db, prisma } from "@/lib/db";
@@ -19,12 +20,7 @@ type RouteContext = { params: Promise<{ id: string }> };
 
 export async function GET(_request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -34,20 +30,14 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     select: { id: true, project_id: true },
   });
   if (!relation) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: relation.project_id },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   const evidence = await prisma.relationEvidence.findMany({
@@ -70,17 +60,12 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     created_at: e.created_at.toISOString(),
   }));
 
-  return NextResponse.json({ data }, { status: 200, headers: { "Cache-Control": "no-store" } });
+  return json({ data });
 }
 
 export async function POST(request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -90,38 +75,23 @@ export async function POST(request: NextRequest, context: RouteContext) {
     select: { id: true, project_id: true, from_type: true, from_id: true },
   });
   if (!relation) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: relation.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON" },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.data;
 
   const parsed = createEvidenceSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -132,10 +102,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
     select: { id: true },
   });
   if (!source) {
-    return NextResponse.json(
-      { error: "Source does not belong to this project" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return json({ error: "Source does not belong to this project" }, { status: 403 });
   }
 
   let evidence: {
@@ -170,9 +137,9 @@ export async function POST(request: NextRequest, context: RouteContext) {
       "code" in err &&
       (err as { code: string }).code === "P2002"
     ) {
-      return NextResponse.json(
+      return json(
         { error: "DUPLICATE_EVIDENCE", message: "This source is already attached as evidence" },
-        { status: 409, headers: { "Cache-Control": "no-store" } },
+        { status: 409 },
       );
     }
     throw err;
@@ -191,7 +158,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
   // The relation list embeds evidence_count — it goes stale on every add.
   await cache.invalidateByPrefix(`relation-list:${relation.project_id}:`);
 
-  return NextResponse.json(
+  return json(
     {
       id: evidence.id,
       relation_id: evidence.relation_id,
@@ -203,6 +170,6 @@ export async function POST(request: NextRequest, context: RouteContext) {
       confidence: evidence.confidence,
       created_at: evidence.created_at.toISOString(),
     },
-    { status: 201, headers: { "Cache-Control": "no-store" } },
+    { status: 201 },
   );
 }

--- a/src/app/api/relations/[id]/evidence/route.ts
+++ b/src/app/api/relations/[id]/evidence/route.ts
@@ -91,7 +91,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
   const parsed = createEvidenceSchema.safeParse(body);
   if (!parsed.success) {
-    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
+    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -102,7 +102,9 @@ export async function POST(request: NextRequest, context: RouteContext) {
     select: { id: true },
   });
   if (!source) {
-    return json({ error: "Source does not belong to this project" }, { status: 403 });
+    return jsonError(403, "INVALID_REFERENCE", {
+      message: "Source does not belong to this project",
+    });
   }
 
   let evidence: {
@@ -137,10 +139,9 @@ export async function POST(request: NextRequest, context: RouteContext) {
       "code" in err &&
       (err as { code: string }).code === "P2002"
     ) {
-      return json(
-        { error: "DUPLICATE_EVIDENCE", message: "This source is already attached as evidence" },
-        { status: 409 },
-      );
+      return jsonError(409, "DUPLICATE_EVIDENCE", {
+        message: "This source is already attached as evidence",
+      });
     }
     throw err;
   }

--- a/src/app/api/relations/[id]/route.ts
+++ b/src/app/api/relations/[id]/route.ts
@@ -1,7 +1,8 @@
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
 import { logActivity } from "@/lib/activity";
+import { forbidden, json, jsonError, notFoundError, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { db, prisma } from "@/lib/db";
@@ -24,12 +25,7 @@ type RouteContext = { params: Promise<{ id: string }> };
 
 export async function GET(_request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -44,10 +40,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   });
 
   if (!relation) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   // Verify project membership
@@ -55,45 +48,34 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     where: { user_id: user.id, project_id: relation.project_id },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
-  return NextResponse.json(
-    {
-      id: relation.id,
-      project_id: relation.project_id,
-      from_type: relation.from_type,
-      from_id: relation.from_id,
-      to_type: relation.to_type,
-      to_id: relation.to_id,
-      relation_type: relation.relation_type,
-      notes: relation.notes,
-      certainty: relation.certainty,
-      valid_from_year: relation.valid_from_year,
-      valid_from_month: relation.valid_from_month,
-      valid_from_cert: relation.valid_from_cert,
-      valid_to_year: relation.valid_to_year,
-      valid_to_month: relation.valid_to_month,
-      valid_to_cert: relation.valid_to_cert,
-      created_at: relation.created_at.toISOString(),
-      updated_at: relation.updated_at.toISOString(),
-      evidence_count: relation._count.evidence,
-    },
-    { status: 200, headers: { "Cache-Control": "no-store" } },
-  );
+  return json({
+    id: relation.id,
+    project_id: relation.project_id,
+    from_type: relation.from_type,
+    from_id: relation.from_id,
+    to_type: relation.to_type,
+    to_id: relation.to_id,
+    relation_type: relation.relation_type,
+    notes: relation.notes,
+    certainty: relation.certainty,
+    valid_from_year: relation.valid_from_year,
+    valid_from_month: relation.valid_from_month,
+    valid_from_cert: relation.valid_from_cert,
+    valid_to_year: relation.valid_to_year,
+    valid_to_month: relation.valid_to_month,
+    valid_to_cert: relation.valid_to_cert,
+    created_at: relation.created_at.toISOString(),
+    updated_at: relation.updated_at.toISOString(),
+    evidence_count: relation._count.evidence,
+  });
 }
 
 export async function PUT(request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -101,38 +83,23 @@ export async function PUT(request: NextRequest, context: RouteContext) {
     where: { id, deleted_at: null },
   });
   if (!existing) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: existing.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON" },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.data;
 
   const parsed = updateRelationSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -169,39 +136,31 @@ export async function PUT(request: NextRequest, context: RouteContext) {
 
   await cache.invalidateByPrefix(`relation-list:${existing.project_id}:`);
 
-  return NextResponse.json(
-    {
-      id: updated.id,
-      project_id: updated.project_id,
-      from_type: updated.from_type,
-      from_id: updated.from_id,
-      to_type: updated.to_type,
-      to_id: updated.to_id,
-      relation_type: updated.relation_type,
-      notes: updated.notes,
-      certainty: updated.certainty,
-      valid_from_year: updated.valid_from_year,
-      valid_from_month: updated.valid_from_month,
-      valid_from_cert: updated.valid_from_cert,
-      valid_to_year: updated.valid_to_year,
-      valid_to_month: updated.valid_to_month,
-      valid_to_cert: updated.valid_to_cert,
-      created_at: updated.created_at.toISOString(),
-      updated_at: updated.updated_at.toISOString(),
-      evidence_count: updated._count.evidence,
-    },
-    { status: 200, headers: { "Cache-Control": "no-store" } },
-  );
+  return json({
+    id: updated.id,
+    project_id: updated.project_id,
+    from_type: updated.from_type,
+    from_id: updated.from_id,
+    to_type: updated.to_type,
+    to_id: updated.to_id,
+    relation_type: updated.relation_type,
+    notes: updated.notes,
+    certainty: updated.certainty,
+    valid_from_year: updated.valid_from_year,
+    valid_from_month: updated.valid_from_month,
+    valid_from_cert: updated.valid_from_cert,
+    valid_to_year: updated.valid_to_year,
+    valid_to_month: updated.valid_to_month,
+    valid_to_cert: updated.valid_to_cert,
+    created_at: updated.created_at.toISOString(),
+    updated_at: updated.updated_at.toISOString(),
+    evidence_count: updated._count.evidence,
+  });
 }
 
 export async function DELETE(_request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -209,20 +168,14 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     where: { id, deleted_at: null },
   });
   if (!relation) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: relation.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   await prisma.relation.update({
@@ -240,8 +193,5 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
 
   await cache.invalidateByPrefix(`relation-list:${relation.project_id}:`);
 
-  return NextResponse.json(
-    { deleted: true },
-    { status: 200, headers: { "Cache-Control": "no-store" } },
-  );
+  return json({ deleted: true });
 }

--- a/src/app/api/relations/[id]/route.ts
+++ b/src/app/api/relations/[id]/route.ts
@@ -99,7 +99,7 @@ export async function PUT(request: NextRequest, context: RouteContext) {
 
   const parsed = updateRelationSchema.safeParse(body);
   if (!parsed.success) {
-    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
+    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;

--- a/src/app/api/relations/bulk/route.test.ts
+++ b/src/app/api/relations/bulk/route.test.ts
@@ -46,7 +46,7 @@ function makeRequest(body: unknown): NextRequest {
 describe("POST /api/relations/bulk", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    mockRequireUser.mockResolvedValue({ id: "user-1", projectId: "proj-1" });
+    mockRequireUser.mockResolvedValue({ id: "user-1", project_id: "proj-1" });
     mockUserProjectFindFirst.mockResolvedValue({ id: "mem-1", role: "OWNER" });
     mockCacheInvalidate.mockResolvedValue(undefined);
   });
@@ -55,7 +55,7 @@ describe("POST /api/relations/bulk", () => {
     mockRelationUpdateMany.mockResolvedValue({ count: 2 });
 
     const res = await POST(
-      makeRequest({ action: "delete", ids: ["rel-1", "rel-2"], projectId: "proj-1" }),
+      makeRequest({ action: "delete", ids: ["rel-1", "rel-2"], project_id: "proj-1" }),
     );
 
     expect(res.status).toBe(200);
@@ -75,24 +75,26 @@ describe("POST /api/relations/bulk", () => {
   });
 
   it("returns 400 when ids is empty", async () => {
-    const res = await POST(makeRequest({ action: "delete", ids: [], projectId: "proj-1" }));
+    const res = await POST(makeRequest({ action: "delete", ids: [], project_id: "proj-1" }));
     expect(res.status).toBe(400);
   });
 
   it("returns 400 when action is not 'delete'", async () => {
-    const res = await POST(makeRequest({ action: "restore", ids: ["rel-1"], projectId: "proj-1" }));
+    const res = await POST(
+      makeRequest({ action: "restore", ids: ["rel-1"], project_id: "proj-1" }),
+    );
     expect(res.status).toBe(400);
   });
 
   it("returns 403 when not OWNER/EDITOR", async () => {
     mockUserProjectFindFirst.mockResolvedValue(null);
-    const res = await POST(makeRequest({ action: "delete", ids: ["rel-1"], projectId: "proj-1" }));
+    const res = await POST(makeRequest({ action: "delete", ids: ["rel-1"], project_id: "proj-1" }));
     expect(res.status).toBe(403);
   });
 
   it("returns 401 when unauthenticated", async () => {
     mockRequireUser.mockResolvedValue(null);
-    const res = await POST(makeRequest({ action: "delete", ids: ["rel-1"], projectId: "proj-1" }));
+    const res = await POST(makeRequest({ action: "delete", ids: ["rel-1"], project_id: "proj-1" }));
     expect(res.status).toBe(401);
   });
 });

--- a/src/app/api/relations/bulk/route.test.ts
+++ b/src/app/api/relations/bulk/route.test.ts
@@ -80,25 +80,19 @@ describe("POST /api/relations/bulk", () => {
   });
 
   it("returns 400 when action is not 'delete'", async () => {
-    const res = await POST(
-      makeRequest({ action: "restore", ids: ["rel-1"], projectId: "proj-1" }),
-    );
+    const res = await POST(makeRequest({ action: "restore", ids: ["rel-1"], projectId: "proj-1" }));
     expect(res.status).toBe(400);
   });
 
   it("returns 403 when not OWNER/EDITOR", async () => {
     mockUserProjectFindFirst.mockResolvedValue(null);
-    const res = await POST(
-      makeRequest({ action: "delete", ids: ["rel-1"], projectId: "proj-1" }),
-    );
+    const res = await POST(makeRequest({ action: "delete", ids: ["rel-1"], projectId: "proj-1" }));
     expect(res.status).toBe(403);
   });
 
   it("returns 401 when unauthenticated", async () => {
     mockRequireUser.mockResolvedValue(null);
-    const res = await POST(
-      makeRequest({ action: "delete", ids: ["rel-1"], projectId: "proj-1" }),
-    );
+    const res = await POST(makeRequest({ action: "delete", ids: ["rel-1"], projectId: "proj-1" }));
     expect(res.status).toBe(401);
   });
 });

--- a/src/app/api/relations/bulk/route.ts
+++ b/src/app/api/relations/bulk/route.ts
@@ -1,16 +1,18 @@
 import { type NextRequest } from "next/server";
-import { z } from "zod";
 
-import { forbidden, json, jsonError, parseJsonBody, unauthorized } from "@/lib/api";
+import {
+  WRITE_ROLES,
+  forbidden,
+  json,
+  parseJsonBody,
+  requireProjectMembership,
+  unauthorized,
+  validateBody,
+} from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { prisma } from "@/lib/db";
-
-const bulkRelationSchema = z.object({
-  action: z.literal("delete"),
-  ids: z.array(z.string()).min(1).max(500),
-  projectId: z.string().min(1),
-});
+import { type BulkDeleteResult, bulkDeleteSchema } from "@/lib/schemas/bulk";
 
 export async function POST(request: NextRequest) {
   const user = await requireUser();
@@ -18,32 +20,22 @@ export async function POST(request: NextRequest) {
 
   const parsedBody = await parseJsonBody(request);
   if (!parsedBody.ok) return parsedBody.response;
-  const body = parsedBody.data;
 
-  const parsed = bulkRelationSchema.safeParse(body);
-  if (!parsed.success) {
-    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
-  }
+  const parsed = validateBody(bulkDeleteSchema, parsedBody.data);
+  if (!parsed.ok) return parsed.response;
 
-  const { ids, projectId } = parsed.data;
+  const { ids, project_id } = parsed.data;
 
-  const membership = await prisma.userProject.findFirst({
-    where: { user_id: user.id, project_id: projectId, role: { in: ["OWNER", "EDITOR"] } },
-  });
-  if (!membership) {
+  if (!(await requireProjectMembership(user.id, project_id, WRITE_ROLES))) {
     return forbidden();
   }
 
   const result = await prisma.relation.updateMany({
-    where: {
-      id: { in: ids },
-      project_id: projectId,
-      deleted_at: null,
-    },
+    where: { id: { in: ids }, project_id, deleted_at: null },
     data: { deleted_at: new Date() },
   });
 
-  await cache.invalidateByPrefix(`relation-list:${projectId}:`);
+  await cache.invalidateByPrefix(`relation-list:${project_id}:`);
 
-  return json({ deleted: result.count });
+  return json<BulkDeleteResult>({ deleted: result.count, skipped: [] });
 }

--- a/src/app/api/relations/bulk/route.ts
+++ b/src/app/api/relations/bulk/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest) {
 
   const parsed = bulkRelationSchema.safeParse(body);
   if (!parsed.success) {
-    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
+    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
   }
 
   const { ids, projectId } = parsed.data;

--- a/src/app/api/relations/bulk/route.ts
+++ b/src/app/api/relations/bulk/route.ts
@@ -1,6 +1,7 @@
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
+import { forbidden, json, jsonError, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { prisma } from "@/lib/db";
@@ -13,29 +14,15 @@ const bulkRelationSchema = z.object({
 
 export async function POST(request: NextRequest) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON" },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.data;
 
   const parsed = bulkRelationSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
   }
 
   const { ids, projectId } = parsed.data;
@@ -44,10 +31,7 @@ export async function POST(request: NextRequest) {
     where: { user_id: user.id, project_id: projectId, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   const result = await prisma.relation.updateMany({
@@ -61,8 +45,5 @@ export async function POST(request: NextRequest) {
 
   await cache.invalidateByPrefix(`relation-list:${projectId}:`);
 
-  return NextResponse.json(
-    { deleted: result.count },
-    { status: 200, headers: { "Cache-Control": "no-store" } },
-  );
+  return json({ deleted: result.count });
 }

--- a/src/app/api/relations/route.test.ts
+++ b/src/app/api/relations/route.test.ts
@@ -142,12 +142,13 @@ describe("GET /api/relations", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       data: { id: string; from_label: string; to_label: string }[];
-      total: number;
+      pagination: { page: number; pageSize: number; total: number; totalPages: number };
     };
     expect(body.data).toHaveLength(1);
     expect(body.data[0]?.from_label).toBe("Max Müller");
     expect(body.data[0]?.to_label).toBe("Anna Müller");
-    expect(body.total).toBe(1);
+    expect(body.pagination.total).toBe(1);
+    expect(body.pagination.totalPages).toBe(1);
   });
 
   it("returns 401 when unauthenticated", async () => {

--- a/src/app/api/relations/route.test.ts
+++ b/src/app/api/relations/route.test.ts
@@ -240,8 +240,8 @@ describe("POST /api/relations", () => {
     );
 
     expect(res.status).toBe(404);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("ENTITY_NOT_FOUND");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("ENTITY_NOT_FOUND");
   });
 
   it("returns 422 when from_type is not in valid_from_types", async () => {
@@ -264,8 +264,8 @@ describe("POST /api/relations", () => {
     );
 
     expect(res.status).toBe(422);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("INVALID_FROM_TYPE");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("INVALID_FROM_TYPE");
   });
 
   it("returns 422 when to_type is not in valid_to_types", async () => {
@@ -288,8 +288,8 @@ describe("POST /api/relations", () => {
     );
 
     expect(res.status).toBe(422);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("INVALID_TO_TYPE");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("INVALID_TO_TYPE");
   });
 
   it("returns 404 when relation_type_id not in project", async () => {
@@ -312,7 +312,7 @@ describe("POST /api/relations", () => {
   it("returns 400 when required fields missing", async () => {
     const res = await POST(makePostRequest({ project_id: "proj-1" }));
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Validation failed");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("VALIDATION_FAILED");
   });
 });

--- a/src/app/api/relations/route.ts
+++ b/src/app/api/relations/route.ts
@@ -1,8 +1,9 @@
 import { type EntityType, type Prisma } from "@prisma/client";
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
 import { logActivity } from "@/lib/activity";
+import { forbidden, json, jsonError, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { db, prisma } from "@/lib/db";
@@ -151,19 +152,14 @@ async function batchResolveLabels(
 
 export async function GET(request: NextRequest) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { searchParams } = request.nextUrl;
   const parsed = listQuerySchema.safeParse(Object.fromEntries(searchParams));
   if (!parsed.success) {
-    return NextResponse.json(
+    return json(
       { error: "Invalid query params", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
+      { status: 400 },
     );
   }
 
@@ -186,16 +182,13 @@ export async function GET(request: NextRequest) {
     where: { user_id: user.id, project_id: projectId },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   const cacheKey = `relation-list:${projectId}:${page}:${pageSize}:${fromType ?? ""}:${fromId ?? ""}:${toType ?? ""}:${toId ?? ""}:${entityType ?? ""}:${entityId ?? ""}:${relationTypeId ?? ""}:${certainty ?? ""}`;
   const cached = await cache.get(cacheKey);
   if (cached) {
-    return NextResponse.json(cached, { status: 200, headers: { "Cache-Control": "no-store" } });
+    return json(cached);
   }
 
   const where: Prisma.RelationWhereInput = { project_id: projectId };
@@ -260,7 +253,7 @@ export async function GET(request: NextRequest) {
 
   await cache.set(cacheKey, body, 60);
 
-  return NextResponse.json(body, { status: 200, headers: { "Cache-Control": "no-store" } });
+  return json(body);
 }
 
 // ---------------------------------------------------------------------------
@@ -269,29 +262,15 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON" },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.data;
 
   const parsed = createRelationSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -301,28 +280,19 @@ export async function POST(request: NextRequest) {
     where: { user_id: user.id, project_id: data.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   // Validate from_id exists
   const fromExists = await validateEntityExists(data.from_type, data.from_id, data.project_id);
   if (!fromExists) {
-    return NextResponse.json(
-      { error: "ENTITY_NOT_FOUND", field: "from_id" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return json({ error: "ENTITY_NOT_FOUND", field: "from_id" }, { status: 404 });
   }
 
   // Validate to_id exists
   const toExists = await validateEntityExists(data.to_type, data.to_id, data.project_id);
   if (!toExists) {
-    return NextResponse.json(
-      { error: "ENTITY_NOT_FOUND", field: "to_id" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return json({ error: "ENTITY_NOT_FOUND", field: "to_id" }, { status: 404 });
   }
 
   // Validate relation_type belongs to same project and check valid types
@@ -330,31 +300,28 @@ export async function POST(request: NextRequest) {
     where: { id: data.relation_type_id, project_id: data.project_id },
   });
   if (!relationType) {
-    return NextResponse.json(
-      { error: "relation_type_id not found or not in this project" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return json({ error: "relation_type_id not found or not in this project" }, { status: 404 });
   }
 
   if (!relationType.valid_from_types.includes(data.from_type)) {
-    return NextResponse.json(
+    return json(
       {
         error: "INVALID_FROM_TYPE",
         message: `from_type '${data.from_type}' is not valid for this relation type`,
         valid_from_types: relationType.valid_from_types,
       },
-      { status: 422, headers: { "Cache-Control": "no-store" } },
+      { status: 422 },
     );
   }
 
   if (!relationType.valid_to_types.includes(data.to_type)) {
-    return NextResponse.json(
+    return json(
       {
         error: "INVALID_TO_TYPE",
         message: `to_type '${data.to_type}' is not valid for this relation type`,
         valid_to_types: relationType.valid_to_types,
       },
-      { status: 422, headers: { "Cache-Control": "no-store" } },
+      { status: 422 },
     );
   }
 
@@ -395,7 +362,7 @@ export async function POST(request: NextRequest) {
 
   await cache.invalidateByPrefix(`relation-list:${data.project_id}:`);
 
-  return NextResponse.json(
+  return json(
     {
       id: relation.id,
       project_id: relation.project_id,
@@ -416,6 +383,6 @@ export async function POST(request: NextRequest) {
       updated_at: relation.updated_at.toISOString(),
       evidence_count: relation._count.evidence,
     },
-    { status: 201, headers: { "Cache-Control": "no-store" } },
+    { status: 201 },
   );
 }

--- a/src/app/api/relations/route.ts
+++ b/src/app/api/relations/route.ts
@@ -157,10 +157,7 @@ export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const parsed = listQuerySchema.safeParse(Object.fromEntries(searchParams));
   if (!parsed.success) {
-    return json(
-      { error: "Invalid query params", details: parsed.error.flatten() },
-      { status: 400 },
-    );
+    return jsonError(400, "INVALID_QUERY_PARAMS", { details: parsed.error.flatten() });
   }
 
   const {
@@ -270,7 +267,7 @@ export async function POST(request: NextRequest) {
 
   const parsed = createRelationSchema.safeParse(body);
   if (!parsed.success) {
-    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
+    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -286,13 +283,13 @@ export async function POST(request: NextRequest) {
   // Validate from_id exists
   const fromExists = await validateEntityExists(data.from_type, data.from_id, data.project_id);
   if (!fromExists) {
-    return json({ error: "ENTITY_NOT_FOUND", field: "from_id" }, { status: 404 });
+    return jsonError(404, "ENTITY_NOT_FOUND", { details: { field: "from_id" } });
   }
 
   // Validate to_id exists
   const toExists = await validateEntityExists(data.to_type, data.to_id, data.project_id);
   if (!toExists) {
-    return json({ error: "ENTITY_NOT_FOUND", field: "to_id" }, { status: 404 });
+    return jsonError(404, "ENTITY_NOT_FOUND", { details: { field: "to_id" } });
   }
 
   // Validate relation_type belongs to same project and check valid types
@@ -300,29 +297,23 @@ export async function POST(request: NextRequest) {
     where: { id: data.relation_type_id, project_id: data.project_id },
   });
   if (!relationType) {
-    return json({ error: "relation_type_id not found or not in this project" }, { status: 404 });
+    return jsonError(404, "INVALID_REFERENCE", {
+      message: "relation_type_id not found or not in this project",
+    });
   }
 
   if (!relationType.valid_from_types.includes(data.from_type)) {
-    return json(
-      {
-        error: "INVALID_FROM_TYPE",
-        message: `from_type '${data.from_type}' is not valid for this relation type`,
-        valid_from_types: relationType.valid_from_types,
-      },
-      { status: 422 },
-    );
+    return jsonError(422, "INVALID_FROM_TYPE", {
+      message: `from_type '${data.from_type}' is not valid for this relation type`,
+      details: { valid_from_types: relationType.valid_from_types },
+    });
   }
 
   if (!relationType.valid_to_types.includes(data.to_type)) {
-    return json(
-      {
-        error: "INVALID_TO_TYPE",
-        message: `to_type '${data.to_type}' is not valid for this relation type`,
-        valid_to_types: relationType.valid_to_types,
-      },
-      { status: 422 },
-    );
+    return jsonError(422, "INVALID_TO_TYPE", {
+      message: `to_type '${data.to_type}' is not valid for this relation type`,
+      details: { valid_to_types: relationType.valid_to_types },
+    });
   }
 
   const relation = await prisma.relation.create({

--- a/src/app/api/relations/route.ts
+++ b/src/app/api/relations/route.ts
@@ -3,7 +3,7 @@ import { type NextRequest } from "next/server";
 import { z } from "zod";
 
 import { logActivity } from "@/lib/activity";
-import { forbidden, json, jsonError, parseJsonBody, unauthorized } from "@/lib/api";
+import { forbidden, json, jsonError, paginated, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { db, prisma } from "@/lib/db";
@@ -246,7 +246,7 @@ export async function GET(request: NextRequest) {
     evidence_count: r._count.evidence,
   }));
 
-  const body = { data, total, page, pageSize };
+  const body = paginated(data, { page, pageSize, total });
 
   await cache.set(cacheKey, body, 60);
 

--- a/src/app/api/sources/[id]/route.test.ts
+++ b/src/app/api/sources/[id]/route.test.ts
@@ -122,8 +122,8 @@ describe("GET /api/sources/[id]", () => {
     const res = await GET(req, makeContext("src-deleted"));
 
     expect(res.status).toBe(404);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Not found");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("NOT_FOUND");
   });
 
   it("returns 403 for non-member", async () => {
@@ -134,8 +134,8 @@ describe("GET /api/sources/[id]", () => {
     const res = await GET(req, makeContext("src-1"));
 
     expect(res.status).toBe(403);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Forbidden");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("FORBIDDEN");
   });
 });
 
@@ -179,8 +179,8 @@ describe("PUT /api/sources/[id]", () => {
     const res = await PUT(req, makeContext("src-1"));
 
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Validation failed");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("VALIDATION_FAILED");
   });
 });
 
@@ -219,7 +219,7 @@ describe("DELETE /api/sources/[id]", () => {
     const res = await DELETE(req, makeContext("src-deleted"));
 
     expect(res.status).toBe(404);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Not found");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("NOT_FOUND");
   });
 });

--- a/src/app/api/sources/[id]/route.ts
+++ b/src/app/api/sources/[id]/route.ts
@@ -105,7 +105,7 @@ export async function PUT(request: NextRequest, context: RouteContext) {
 
   const parsed = updateSourceSchema.safeParse(body);
   if (!parsed.success) {
-    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
+    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;

--- a/src/app/api/sources/[id]/route.ts
+++ b/src/app/api/sources/[id]/route.ts
@@ -1,7 +1,8 @@
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
 import { logActivity } from "@/lib/activity";
+import { forbidden, json, jsonError, notFoundError, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { db, prisma } from "@/lib/db";
@@ -35,12 +36,7 @@ const sourceDetailInclude = {
 
 export async function GET(_request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -50,20 +46,14 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   });
 
   if (!source) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: source.project_id },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   const body = {
@@ -86,17 +76,12 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     },
   };
 
-  return NextResponse.json(body, { status: 200, headers: { "Cache-Control": "no-store" } });
+  return json(body);
 }
 
 export async function PUT(request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -104,38 +89,23 @@ export async function PUT(request: NextRequest, context: RouteContext) {
     where: { id, deleted_at: null },
   });
   if (!existing) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: existing.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON" },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.data;
 
   const parsed = updateSourceSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -211,17 +181,12 @@ export async function PUT(request: NextRequest, context: RouteContext) {
     },
   };
 
-  return NextResponse.json(responseBody, { status: 200, headers: { "Cache-Control": "no-store" } });
+  return json(responseBody);
 }
 
 export async function DELETE(_request: NextRequest, context: RouteContext) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { id } = await context.params;
 
@@ -229,20 +194,14 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
     where: { id, deleted_at: null },
   });
   if (!source) {
-    return NextResponse.json(
-      { error: "Not found" },
-      { status: 404, headers: { "Cache-Control": "no-store" } },
-    );
+    return notFoundError();
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: source.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   await prisma.source.update({
@@ -252,8 +211,5 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
 
   await cache.invalidateByPrefix(`source-list:${source.project_id}:`);
 
-  return NextResponse.json(
-    { success: true },
-    { status: 200, headers: { "Cache-Control": "no-store" } },
-  );
+  return json({ success: true });
 }

--- a/src/app/api/sources/bulk/route.test.ts
+++ b/src/app/api/sources/bulk/route.test.ts
@@ -61,7 +61,7 @@ describe("POST /api/sources/bulk", () => {
   it("bulk deletes 2 sources and returns { deleted: 2 }", async () => {
     mockSourceUpdateMany.mockResolvedValue({ count: 2 });
 
-    const req = makeRequest({ ids: ["src-1", "src-2"], project_id: "proj-1" });
+    const req = makeRequest({ action: "delete", ids: ["src-1", "src-2"], project_id: "proj-1" });
     const res = await POST(req);
 
     expect(res.status).toBe(200);
@@ -85,7 +85,11 @@ describe("POST /api/sources/bulk", () => {
     // Only 1 of the 2 IDs belongs to the project — updateMany handles this via where clause
     mockSourceUpdateMany.mockResolvedValue({ count: 1 });
 
-    const req = makeRequest({ ids: ["src-proj1", "src-other-project"], project_id: "proj-1" });
+    const req = makeRequest({
+      action: "delete",
+      ids: ["src-proj1", "src-other-project"],
+      project_id: "proj-1",
+    });
     const res = await POST(req);
 
     expect(res.status).toBe(200);
@@ -94,7 +98,7 @@ describe("POST /api/sources/bulk", () => {
   });
 
   it("returns 400 for empty ids array", async () => {
-    const req = makeRequest({ ids: [], project_id: "proj-1" });
+    const req = makeRequest({ action: "delete", ids: [], project_id: "proj-1" });
     const res = await POST(req);
 
     expect(res.status).toBe(400);

--- a/src/app/api/sources/bulk/route.test.ts
+++ b/src/app/api/sources/bulk/route.test.ts
@@ -98,7 +98,7 @@ describe("POST /api/sources/bulk", () => {
     const res = await POST(req);
 
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Validation failed");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("VALIDATION_FAILED");
   });
 });

--- a/src/app/api/sources/bulk/route.ts
+++ b/src/app/api/sources/bulk/route.ts
@@ -1,15 +1,18 @@
 import { type NextRequest } from "next/server";
-import { z } from "zod";
 
-import { forbidden, json, jsonError, parseJsonBody, unauthorized } from "@/lib/api";
+import {
+  WRITE_ROLES,
+  forbidden,
+  json,
+  parseJsonBody,
+  requireProjectMembership,
+  unauthorized,
+  validateBody,
+} from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { prisma } from "@/lib/db";
-
-const bulkSourceSchema = z.object({
-  ids: z.array(z.string()).min(1).max(100),
-  project_id: z.string().min(1),
-});
+import { type BulkDeleteResult, bulkDeleteSchema } from "@/lib/schemas/bulk";
 
 export async function POST(request: NextRequest) {
   const user = await requireUser();
@@ -17,32 +20,22 @@ export async function POST(request: NextRequest) {
 
   const parsedBody = await parseJsonBody(request);
   if (!parsedBody.ok) return parsedBody.response;
-  const body = parsedBody.data;
 
-  const parsed = bulkSourceSchema.safeParse(body);
-  if (!parsed.success) {
-    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
-  }
+  const parsed = validateBody(bulkDeleteSchema, parsedBody.data);
+  if (!parsed.ok) return parsed.response;
 
   const { ids, project_id } = parsed.data;
 
-  const membership = await prisma.userProject.findFirst({
-    where: { user_id: user.id, project_id, role: { in: ["OWNER", "EDITOR"] } },
-  });
-  if (!membership) {
+  if (!(await requireProjectMembership(user.id, project_id, WRITE_ROLES))) {
     return forbidden();
   }
 
   const result = await prisma.source.updateMany({
-    where: {
-      id: { in: ids },
-      project_id,
-      deleted_at: null,
-    },
+    where: { id: { in: ids }, project_id, deleted_at: null },
     data: { deleted_at: new Date() },
   });
 
   await cache.invalidateByPrefix(`source-list:${project_id}:`);
 
-  return json({ deleted: result.count });
+  return json<BulkDeleteResult>({ deleted: result.count, skipped: [] });
 }

--- a/src/app/api/sources/bulk/route.ts
+++ b/src/app/api/sources/bulk/route.ts
@@ -1,6 +1,7 @@
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
+import { forbidden, json, jsonError, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { prisma } from "@/lib/db";
@@ -12,29 +13,15 @@ const bulkSourceSchema = z.object({
 
 export async function POST(request: NextRequest) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON" },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.data;
 
   const parsed = bulkSourceSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
   }
 
   const { ids, project_id } = parsed.data;
@@ -43,10 +30,7 @@ export async function POST(request: NextRequest) {
     where: { user_id: user.id, project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   const result = await prisma.source.updateMany({
@@ -60,8 +44,5 @@ export async function POST(request: NextRequest) {
 
   await cache.invalidateByPrefix(`source-list:${project_id}:`);
 
-  return NextResponse.json(
-    { deleted: result.count },
-    { status: 200, headers: { "Cache-Control": "no-store" } },
-  );
+  return json({ deleted: result.count });
 }

--- a/src/app/api/sources/bulk/route.ts
+++ b/src/app/api/sources/bulk/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: NextRequest) {
 
   const parsed = bulkSourceSchema.safeParse(body);
   if (!parsed.success) {
-    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
+    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
   }
 
   const { ids, project_id } = parsed.data;

--- a/src/app/api/sources/route.test.ts
+++ b/src/app/api/sources/route.test.ts
@@ -190,8 +190,8 @@ describe("GET /api/sources", () => {
     const res = await GET(req);
 
     expect(res.status).toBe(401);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Unauthorized");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("UNAUTHORIZED");
   });
 
   it("returns 400 for invalid pageSize", async () => {
@@ -199,8 +199,8 @@ describe("GET /api/sources", () => {
     const res = await GET(req);
 
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Invalid query params");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("INVALID_QUERY_PARAMS");
   });
 
   it("returns cached result on second call", async () => {
@@ -277,7 +277,7 @@ describe("POST /api/sources", () => {
     const res = await POST(req);
 
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("Validation failed");
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("VALIDATION_FAILED");
   });
 });

--- a/src/app/api/sources/route.ts
+++ b/src/app/api/sources/route.ts
@@ -1,7 +1,8 @@
 import { type Prisma } from "@prisma/client";
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { z } from "zod";
 
+import { forbidden, json, jsonError, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { db, prisma } from "@/lib/db";
@@ -54,39 +55,28 @@ function buildSourceSummary(source: {
 
 export async function GET(request: NextRequest) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
   const { searchParams } = request.nextUrl;
   const parsed = listQuerySchema.safeParse(Object.fromEntries(searchParams));
   if (!parsed.success) {
-    return NextResponse.json(
+    return json(
       { error: "Invalid query params", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
+      { status: 400 },
     );
   }
 
   const { page, pageSize, search, sort, order } = parsed.data;
   const projectId = parsed.data.projectId ?? user.projectId;
   if (!projectId) {
-    return NextResponse.json(
-      { error: "No project" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return json({ error: "No project" }, { status: 403 });
   }
 
   const membership = await prisma.userProject.findFirst({
     where: { user_id: user.id, project_id: projectId },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   const reliabilityValues = parsed.data.reliability
@@ -97,7 +87,7 @@ export async function GET(request: NextRequest) {
   const cacheKey = `source-list:${projectId}:${page}:${pageSize}:${search ?? ""}:${sort}:${order}:${reliabilityValues.join(",")}:${encodeURIComponent(typeFilter ?? "")}`;
   const cached = await cache.get(cacheKey);
   if (cached) {
-    return NextResponse.json(cached, { status: 200, headers: { "Cache-Control": "no-store" } });
+    return json(cached);
   }
 
   const where: Prisma.SourceWhereInput = {
@@ -141,34 +131,20 @@ export async function GET(request: NextRequest) {
 
   await cache.set(cacheKey, body, 60);
 
-  return NextResponse.json(body, { status: 200, headers: { "Cache-Control": "no-store" } });
+  return json(body);
 }
 
 export async function POST(request: NextRequest) {
   const user = await requireUser();
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  if (!user) return unauthorized();
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON" },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
-  }
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.data;
 
   const parsed = createSourceSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400, headers: { "Cache-Control": "no-store" } },
-    );
+    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;
@@ -177,10 +153,7 @@ export async function POST(request: NextRequest) {
     where: { user_id: user.id, project_id: data.project_id, role: { in: ["OWNER", "EDITOR"] } },
   });
   if (!membership) {
-    return NextResponse.json(
-      { error: "Forbidden" },
-      { status: 403, headers: { "Cache-Control": "no-store" } },
-    );
+    return forbidden();
   }
 
   const source = await prisma.source.create({
@@ -229,5 +202,5 @@ export async function POST(request: NextRequest) {
     },
   };
 
-  return NextResponse.json(responseBody, { status: 201, headers: { "Cache-Control": "no-store" } });
+  return json(responseBody, { status: 201 });
 }

--- a/src/app/api/sources/route.ts
+++ b/src/app/api/sources/route.ts
@@ -60,16 +60,13 @@ export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const parsed = listQuerySchema.safeParse(Object.fromEntries(searchParams));
   if (!parsed.success) {
-    return json(
-      { error: "Invalid query params", details: parsed.error.flatten() },
-      { status: 400 },
-    );
+    return jsonError(400, "INVALID_QUERY_PARAMS", { details: parsed.error.flatten() });
   }
 
   const { page, pageSize, search, sort, order } = parsed.data;
   const projectId = parsed.data.projectId ?? user.projectId;
   if (!projectId) {
-    return json({ error: "No project" }, { status: 403 });
+    return jsonError(403, "NO_PROJECT");
   }
 
   const membership = await prisma.userProject.findFirst({
@@ -144,7 +141,7 @@ export async function POST(request: NextRequest) {
 
   const parsed = createSourceSchema.safeParse(body);
   if (!parsed.success) {
-    return jsonError(400, "Validation failed", { details: parsed.error.flatten() });
+    return jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() });
   }
 
   const data = parsed.data;

--- a/src/app/api/sources/route.ts
+++ b/src/app/api/sources/route.ts
@@ -2,7 +2,7 @@ import { type Prisma } from "@prisma/client";
 import { type NextRequest } from "next/server";
 import { z } from "zod";
 
-import { forbidden, json, jsonError, parseJsonBody, unauthorized } from "@/lib/api";
+import { forbidden, json, jsonError, paginated, parseJsonBody, unauthorized } from "@/lib/api";
 import { requireUser } from "@/lib/auth-guard";
 import { cache } from "@/lib/cache";
 import { db, prisma } from "@/lib/db";
@@ -116,15 +116,7 @@ export async function GET(request: NextRequest) {
     prisma.source.count({ where: { ...where, deleted_at: null } }),
   ]);
 
-  const body = {
-    data: sources.map(buildSourceSummary),
-    pagination: {
-      page,
-      pageSize,
-      total,
-      totalPages: Math.ceil(total / pageSize),
-    },
-  };
+  const body = paginated(sources.map(buildSourceSummary), { page, pageSize, total });
 
   await cache.set(cacheKey, body, 60);
 

--- a/src/components/auth/ResetPasswordForm.test.tsx
+++ b/src/components/auth/ResetPasswordForm.test.tsx
@@ -28,10 +28,7 @@ describe("ResetPasswordForm", () => {
   });
 
   it("calls router.push to login page on successful 200 response", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValueOnce({ ok: true, status: 200 } as Response),
-    );
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce({ ok: true, status: 200 } as Response));
 
     renderWithProviders(<ResetPasswordForm token="valid-token" />);
 
@@ -56,7 +53,7 @@ describe("ResetPasswordForm", () => {
       vi.fn().mockResolvedValueOnce({
         ok: false,
         status: 400,
-        json: () => Promise.resolve({ error: "auth.errors.tokenExpired" }),
+        json: () => Promise.resolve({ error: { code: "TOKEN_EXPIRED" } }),
       } as Response),
     );
 

--- a/src/components/auth/ResetPasswordForm.tsx
+++ b/src/components/auth/ResetPasswordForm.tsx
@@ -12,6 +12,7 @@ import { PasswordStrengthIndicator } from "@/components/auth/PasswordStrengthInd
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { errorCode, readErrorBody, translateErrorCode } from "@/lib/api-error";
 
 const resetSchema = z
   .object({
@@ -67,19 +68,18 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
         }),
       });
       if (res.status === 400) {
-        const data = (await res.json()) as { error?: string };
-        if (
-          data.error === "auth.errors.tokenExpired" ||
-          data.error === "auth.errors.tokenInvalid"
-        ) {
-          setServerError(
-            t(
-              `errors.${data.error === "auth.errors.tokenExpired" ? "tokenExpired" : "tokenInvalid"}`,
-            ),
-          );
-        } else {
-          setServerError(t("errors.serverError"));
-        }
+        const code = errorCode(await readErrorBody(res));
+        setServerError(
+          translateErrorCode(
+            code,
+            t,
+            {
+              TOKEN_EXPIRED: "errors.tokenExpired",
+              TOKEN_INVALID: "errors.tokenInvalid",
+            },
+            "errors.serverError",
+          ),
+        );
         return;
       }
       if (!res.ok) {
@@ -97,7 +97,7 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
       {serverError && (
-        <div role="alert" className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+        <div role="alert" className="bg-destructive/10 text-destructive rounded-md p-3 text-sm">
           {serverError}
         </div>
       )}
@@ -114,16 +114,14 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
           />
           <button
             type="button"
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+            className="text-muted-foreground absolute top-1/2 right-3 -translate-y-1/2"
             onClick={() => setShowPassword((v) => !v)}
             aria-label={showPassword ? "Hide password" : "Show password"}
           >
             {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
           </button>
         </div>
-        {errors.password && (
-          <p className="text-xs text-destructive">{errors.password.message}</p>
-        )}
+        {errors.password && <p className="text-destructive text-xs">{errors.password.message}</p>}
         <PasswordStrengthIndicator password={password} />
       </div>
       <div className="space-y-1">
@@ -136,7 +134,7 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
           aria-invalid={!!errors.passwordConfirm}
         />
         {errors.passwordConfirm && (
-          <p className="text-xs text-destructive">{errors.passwordConfirm.message}</p>
+          <p className="text-destructive text-xs">{errors.passwordConfirm.message}</p>
         )}
       </div>
       <Button type="submit" className="w-full" disabled={isSubmitting}>

--- a/src/components/auth/VerifyEmailCard.test.tsx
+++ b/src/components/auth/VerifyEmailCard.test.tsx
@@ -30,10 +30,7 @@ describe("VerifyEmailCard", () => {
   });
 
   it("shows pending then success when fetch returns 200", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValueOnce({ ok: true, status: 200 } as Response),
-    );
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce({ ok: true, status: 200 } as Response));
 
     renderWithProviders(<VerifyEmailCard token="valid-token" />);
 
@@ -53,7 +50,7 @@ describe("VerifyEmailCard", () => {
       vi.fn().mockResolvedValueOnce({
         ok: false,
         status: 400,
-        json: () => Promise.resolve({ error: "auth.errors.tokenInvalid" }),
+        json: () => Promise.resolve({ error: { code: "TOKEN_INVALID" } }),
       } as Response),
     );
 

--- a/src/components/auth/VerifyEmailCard.tsx
+++ b/src/components/auth/VerifyEmailCard.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 
+import { errorCode, readErrorBody } from "@/lib/api-error";
+
 interface VerifyEmailCardProps {
   token: string | null;
 }
@@ -31,12 +33,8 @@ export function VerifyEmailCard({ token }: VerifyEmailCardProps) {
         if (res.ok) {
           setState("success");
         } else {
-          const data = (await res.json()) as { error?: string };
-          if (data.error === "auth.errors.tokenExpired") {
-            setErrorKey("tokenExpired");
-          } else {
-            setErrorKey("tokenInvalid");
-          }
+          const code = errorCode(await readErrorBody(res));
+          setErrorKey(code === "TOKEN_EXPIRED" ? "tokenExpired" : "tokenInvalid");
           setState("error");
         }
       } catch {
@@ -52,7 +50,7 @@ export function VerifyEmailCard({ token }: VerifyEmailCardProps) {
 
   if (state === "pending") {
     return (
-      <div className="flex items-center gap-2 text-muted-foreground">
+      <div className="text-muted-foreground flex items-center gap-2">
         <Loader2 className="h-4 w-4 animate-spin" />
         <span>{t("verify.verifying")}</span>
       </div>
@@ -66,8 +64,8 @@ export function VerifyEmailCard({ token }: VerifyEmailCardProps) {
           <CheckCircle className="h-5 w-5" />
           <span className="font-medium">{t("verify.success")}</span>
         </div>
-        <p className="text-sm text-muted-foreground">{t("verify.successMessage")}</p>
-        <Link href="/auth/login" className="text-sm text-primary hover:underline">
+        <p className="text-muted-foreground text-sm">{t("verify.successMessage")}</p>
+        <Link href="/auth/login" className="text-primary text-sm hover:underline">
           {t("verify.loginNow")} →
         </Link>
       </div>
@@ -76,12 +74,12 @@ export function VerifyEmailCard({ token }: VerifyEmailCardProps) {
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center gap-2 text-destructive">
+      <div className="text-destructive flex items-center gap-2">
         <XCircle className="h-5 w-5" />
         <span className="font-medium">{t("errors.tokenInvalid")}</span>
       </div>
-      <p className="text-sm text-muted-foreground">{t(`errors.${errorKey}`)}</p>
-      <Link href="/auth/forgot-password" className="text-sm text-primary hover:underline">
+      <p className="text-muted-foreground text-sm">{t(`errors.${errorKey}`)}</p>
+      <Link href="/auth/forgot-password" className="text-primary text-sm hover:underline">
         {t("verify.requestNew")} →
       </Link>
     </div>

--- a/src/components/relations/ActivityLog.tsx
+++ b/src/components/relations/ActivityLog.tsx
@@ -54,12 +54,12 @@ export function ActivityLog({ projectId, entityType, entityId, refreshKey }: Act
       setLoading(true);
       try {
         const res = await fetch(
-          `/api/entities/${entityType.toLowerCase()}/${entityId}/activity?projectId=${encodeURIComponent(projectId)}&page=${p}&limit=${PAGE_SIZE}`,
+          `/api/entities/${entityType.toLowerCase()}/${entityId}/activity?projectId=${encodeURIComponent(projectId)}&page=${p}&pageSize=${PAGE_SIZE}`,
         );
         if (res.ok) {
           const data = (await res.json()) as {
             data?: ActivityEntry[];
-            hasMore?: boolean;
+            pagination?: { page: number; totalPages: number };
           };
           const items = data.data ?? [];
           if (p === 1) {
@@ -67,7 +67,10 @@ export function ActivityLog({ projectId, entityType, entityId, refreshKey }: Act
           } else {
             setEntries((prev) => [...prev, ...items]);
           }
-          setHasMore(data.hasMore ?? items.length === PAGE_SIZE);
+          // The endpoint never returned `hasMore`; the old fallback guessed from
+          // page length and was wrong when the last page was exactly PAGE_SIZE.
+          const pagination = data.pagination;
+          setHasMore(pagination ? pagination.page < pagination.totalPages : false);
         }
       } finally {
         setLoading(false);
@@ -89,14 +92,14 @@ export function ActivityLog({ projectId, entityType, entityId, refreshKey }: Act
 
   if (loading && entries.length === 0) {
     return (
-      <div className="flex items-center gap-2 py-8 text-muted-foreground">
+      <div className="text-muted-foreground flex items-center gap-2 py-8">
         <Loader2 className="h-4 w-4 animate-spin" />
       </div>
     );
   }
 
   if (!loading && entries.length === 0) {
-    return <p className="text-sm text-muted-foreground">{t("noActivity")}</p>;
+    return <p className="text-muted-foreground text-sm">{t("noActivity")}</p>;
   }
 
   return (
@@ -119,7 +122,7 @@ export function ActivityLog({ projectId, entityType, entityId, refreshKey }: Act
                   <span className="text-muted-foreground"> · {entry.field_path}</span>
                 )}
               </p>
-              <p className="text-xs text-muted-foreground">
+              <p className="text-muted-foreground text-xs">
                 {formatRelativeTime(entry.created_at)}
               </p>
             </div>

--- a/src/components/relations/EntitySelector.tsx
+++ b/src/components/relations/EntitySelector.tsx
@@ -67,6 +67,7 @@ export function EntitySelector({
   displayLabel,
 }: EntitySelectorProps) {
   const t = useTranslations("relationTypes");
+  const tSel = useTranslations("entitySelector");
   const availableTypes = allowedTypes ?? ALL_TYPES;
   const [selectedType, setSelectedType] = useState<EntityType>(availableTypes[0] ?? "PERSON");
   const [open, setOpen] = useState(false);
@@ -147,7 +148,7 @@ export function EntitySelector({
       });
   }, [debouncedQuery, open, selectedType, projectId]);
 
-  const displayPlaceholder = placeholder ?? "Entität auswählen…";
+  const displayPlaceholder = placeholder ?? tSel("placeholder");
 
   function handleSelect(item: EntityOption) {
     setSelectedLabel(item.label);
@@ -175,7 +176,7 @@ export function EntitySelector({
             size="sm"
             className="h-6 w-6 p-0"
             onClick={handleClear}
-            aria-label="Auswahl entfernen"
+            aria-label={tSel("clear")}
           >
             <X className="h-3 w-3" />
           </Button>
@@ -217,10 +218,12 @@ export function EntitySelector({
         </PopoverTrigger>
         <PopoverContent className="w-64 p-0" align="start">
           <Command>
-            <CommandInput placeholder="Suchen…" value={query} onValueChange={setQuery} />
+            <CommandInput placeholder={tSel("search")} value={query} onValueChange={setQuery} />
             <CommandList>
               {searching && (
-                <div className="text-muted-foreground py-2 text-center text-sm">Suche…</div>
+                <div className="text-muted-foreground py-2 text-center text-sm">
+                  {tSel("searching")}
+                </div>
               )}
               {!searching && query.length < 1 && (
                 <div className="text-muted-foreground py-2 text-center text-sm">
@@ -228,7 +231,7 @@ export function EntitySelector({
                 </div>
               )}
               {!searching && query.length >= 1 && results.length === 0 && (
-                <CommandEmpty>Keine Ergebnisse.</CommandEmpty>
+                <CommandEmpty>{tSel("no_results")}</CommandEmpty>
               )}
               {results.length > 0 && (
                 <CommandGroup>

--- a/src/components/relations/EntitySelector.tsx
+++ b/src/components/relations/EntitySelector.tsx
@@ -16,6 +16,7 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Select } from "@/components/ui/select";
 
 interface EntityOption {
   id: string;
@@ -188,8 +189,8 @@ export function EntitySelector({
   return (
     <div className="flex items-center gap-2">
       {availableTypes.length > 1 && (
-        <select
-          className="border-input bg-background rounded-md border px-2 py-1 text-sm"
+        <Select
+          className="h-auto w-auto px-2 py-1"
           value={selectedType}
           onChange={(e) => {
             setSelectedType(e.target.value as EntityType);
@@ -203,7 +204,7 @@ export function EntitySelector({
               {t(`entityTypes.${type}`)}
             </option>
           ))}
-        </select>
+        </Select>
       )}
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>

--- a/src/components/relations/EvidenceForm.tsx
+++ b/src/components/relations/EvidenceForm.tsx
@@ -76,7 +76,7 @@ export function EvidenceForm({ projectId, onSubmit, onCancel }: EvidenceFormProp
         confidence,
       });
     } catch {
-      setError("Fehler beim Speichern.");
+      setError(t("save_failed"));
     } finally {
       setSubmitting(false);
     }
@@ -107,7 +107,7 @@ export function EvidenceForm({ projectId, onSubmit, onCancel }: EvidenceFormProp
             <Input
               value={sourceQuery}
               onChange={(e) => void handleSourceSearch(e.target.value)}
-              placeholder="Quelle suchen…"
+              placeholder={t("search_source")}
             />
             {sourceResults.length > 0 && (
               <div className="bg-background absolute z-10 mt-1 w-full rounded-md border shadow-lg">
@@ -137,7 +137,7 @@ export function EvidenceForm({ projectId, onSubmit, onCancel }: EvidenceFormProp
         <Input
           value={pageReference}
           onChange={(e) => setPageReference(e.target.value)}
-          placeholder="z. B. S. 42, fol. 3v"
+          placeholder={t("page_reference_placeholder")}
         />
       </div>
 
@@ -147,7 +147,7 @@ export function EvidenceForm({ projectId, onSubmit, onCancel }: EvidenceFormProp
         <Input
           value={quote}
           onChange={(e) => setQuote(e.target.value)}
-          placeholder="Relevantes Zitat"
+          placeholder={t("quote_placeholder")}
         />
       </div>
 

--- a/src/components/relations/EvidenceList.tsx
+++ b/src/components/relations/EvidenceList.tsx
@@ -34,7 +34,7 @@ export function EvidenceList({ items, projectId, onAdd, onDelete, loading }: Evi
       await onDelete(id);
       toast.success(t("deleted_toast"));
     } catch {
-      toast.error("Fehler beim Löschen.");
+      toast.error(t("delete_failed"));
     } finally {
       setDeletingId(null);
     }
@@ -47,7 +47,7 @@ export function EvidenceList({ items, projectId, onAdd, onDelete, loading }: Evi
 
   if (loading) {
     return (
-      <div className="flex items-center gap-2 py-4 text-muted-foreground">
+      <div className="text-muted-foreground flex items-center gap-2 py-4">
         <Loader2 className="h-4 w-4 animate-spin" />
       </div>
     );
@@ -56,7 +56,7 @@ export function EvidenceList({ items, projectId, onAdd, onDelete, loading }: Evi
   return (
     <div className="space-y-3">
       {items.length === 0 && !showForm && (
-        <p className="text-sm text-muted-foreground">{t("noEvidence")}</p>
+        <p className="text-muted-foreground text-sm">{t("noEvidence")}</p>
       )}
 
       <div className="max-h-48 space-y-2 overflow-y-auto">
@@ -71,9 +71,9 @@ export function EvidenceList({ items, projectId, onAdd, onDelete, loading }: Evi
                 <p className="text-muted-foreground">{item.page_reference}</p>
               )}
               {item.quote && (
-                <p className="italic text-muted-foreground">&ldquo;{item.quote}&rdquo;</p>
+                <p className="text-muted-foreground italic">&ldquo;{item.quote}&rdquo;</p>
               )}
-              <p className="text-xs text-muted-foreground">{item.confidence}</p>
+              <p className="text-muted-foreground text-xs">{item.confidence}</p>
             </div>
             <Button
               type="button"

--- a/src/components/relations/RelationDeleteButton.tsx
+++ b/src/components/relations/RelationDeleteButton.tsx
@@ -63,7 +63,7 @@ export function RelationDeleteButton({ relationId, onDeleted }: RelationDeleteBu
             <AlertDialogDescription>{t("deleteConfirm")}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleting}>Abbrechen</AlertDialogCancel>
+            <AlertDialogCancel disabled={deleting}>{t("cancel")}</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => void handleConfirm()}
               disabled={deleting}

--- a/src/components/relations/RelationDeleteButton.tsx
+++ b/src/components/relations/RelationDeleteButton.tsx
@@ -36,8 +36,7 @@ export function RelationDeleteButton({ relationId, onDeleted }: RelationDeleteBu
         onDeleted();
         setOpen(false);
       } else {
-        const data = (await res.json().catch(() => ({}))) as { error?: string };
-        toast.error(data.error ?? "Fehler beim Löschen.");
+        toast.error(t("delete_failed"));
       }
     } finally {
       setDeleting(false);

--- a/src/components/relations/RelationFormDialog.tsx
+++ b/src/components/relations/RelationFormDialog.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import { useRelationTypes } from "@/hooks/use-relation-types";
 import type { RelationWithDetails } from "@/types/relations";
 
@@ -204,7 +205,7 @@ export function RelationFormDialog({
           {/* Notes */}
           <div className="space-y-1">
             <Label>{t("fields.notes")}</Label>
-            <textarea
+            <Textarea
               className="border-input bg-background placeholder:text-muted-foreground focus-visible:ring-ring w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-1 focus-visible:outline-none"
               rows={2}
               value={notes}
@@ -311,7 +312,7 @@ export function RelationFormDialog({
                   </div>
                   <div className="space-y-1">
                     <Label>{t("fields.evidenceQuote")}</Label>
-                    <textarea
+                    <Textarea
                       className="border-input bg-background placeholder:text-muted-foreground focus-visible:ring-ring w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-1 focus-visible:outline-none"
                       rows={2}
                       value={evidenceQuote}

--- a/src/components/relations/RelationFormDialog.tsx
+++ b/src/components/relations/RelationFormDialog.tsx
@@ -236,14 +236,14 @@ export function RelationFormDialog({
                   <div className="flex gap-2">
                     <Input
                       type="number"
-                      placeholder="Jahr"
+                      placeholder={t("year_placeholder")}
                       value={validFromYear}
                       onChange={(e) => setValidFromYear(e.target.value)}
                       className="w-24"
                     />
                     <Input
                       type="number"
-                      placeholder="Monat"
+                      placeholder={t("month_placeholder")}
                       min={1}
                       max={12}
                       value={validFromMonth}
@@ -259,14 +259,14 @@ export function RelationFormDialog({
                   <div className="flex gap-2">
                     <Input
                       type="number"
-                      placeholder="Jahr"
+                      placeholder={t("year_placeholder")}
                       value={validToYear}
                       onChange={(e) => setValidToYear(e.target.value)}
                       className="w-24"
                     />
                     <Input
                       type="number"
-                      placeholder="Monat"
+                      placeholder={t("month_placeholder")}
                       min={1}
                       max={12}
                       value={validToMonth}

--- a/src/components/relations/RelationTypeSelector.tsx
+++ b/src/components/relations/RelationTypeSelector.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 
+import { Select } from "@/components/ui/select";
 import type { RelationTypeItem } from "@/types/relations";
 
 interface RelationTypeSelectorProps {
@@ -31,18 +32,17 @@ export function RelationTypeSelector({
   const filtered =
     fromType && toType
       ? allTypes.filter(
-          (rt) =>
-            rt.valid_from_types.includes(fromType) && rt.valid_to_types.includes(toType),
+          (rt) => rt.valid_from_types.includes(fromType) && rt.valid_to_types.includes(toType),
         )
       : allTypes;
 
   if (fromType && toType && filtered.length === 0) {
     return (
       <div className="space-y-1">
-        <p className="text-sm text-muted-foreground">{t("noTypeForCombination")}</p>
+        <p className="text-muted-foreground text-sm">{t("noTypeForCombination")}</p>
         <Link
           href={`/${locale}/settings/relation-types`}
-          className="text-xs text-primary underline hover:text-primary/80"
+          className="text-primary hover:text-primary/80 text-xs underline"
         >
           {t("manageTypes")}
         </Link>
@@ -51,8 +51,8 @@ export function RelationTypeSelector({
   }
 
   return (
-    <select
-      className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+    <Select
+      className="border-input bg-background w-full rounded-md border px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
       value={value ?? ""}
       onChange={(e) => onChange(e.target.value || null)}
       disabled={disabled}
@@ -64,6 +64,6 @@ export function RelationTypeSelector({
           {rt.inverse_name ? ` / ${rt.inverse_name}` : ""}
         </option>
       ))}
-    </select>
+    </Select>
   );
 }

--- a/src/components/relations/RelationsTab.tsx
+++ b/src/components/relations/RelationsTab.tsx
@@ -43,12 +43,10 @@ export function RelationsTab({
         `/api/relations?entityType=${entityType}&entityId=${encodeURIComponent(entityId)}&projectId=${encodeURIComponent(projectId)}`,
       );
       if (res.ok) {
-        const data = (await res.json()) as RelationWithDetails[] | { data?: RelationWithDetails[] };
-        if (Array.isArray(data)) {
-          setRelations(data);
-        } else if (data && Array.isArray((data as { data?: RelationWithDetails[] }).data)) {
-          setRelations((data as { data: RelationWithDetails[] }).data);
-        }
+        // The list envelope is now uniform, so the old
+        // `Array.isArray(data) ? … : data.data` normalisation is gone.
+        const data = (await res.json()) as { data?: RelationWithDetails[] };
+        setRelations(data.data ?? []);
       }
     } finally {
       setLoading(false);
@@ -78,7 +76,7 @@ export function RelationsTab({
 
   if (loading) {
     return (
-      <div className="flex items-center gap-2 py-8 text-muted-foreground">
+      <div className="text-muted-foreground flex items-center gap-2 py-8">
         <Loader2 className="h-4 w-4 animate-spin" />
       </div>
     );
@@ -95,11 +93,11 @@ export function RelationsTab({
 
       {/* Outgoing relations */}
       <div className="space-y-2">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
           {t("outgoing")}
         </p>
         {outgoing.length === 0 ? (
-          <p className="text-sm text-muted-foreground">{t("noRelations")}</p>
+          <p className="text-muted-foreground text-sm">{t("noRelations")}</p>
         ) : (
           outgoing.map((r) => (
             <RelationRow
@@ -120,11 +118,11 @@ export function RelationsTab({
 
       {/* Incoming relations */}
       <div className="space-y-2">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
           {t("incoming")}
         </p>
         {incoming.length === 0 ? (
-          <p className="text-sm text-muted-foreground">{t("noRelations")}</p>
+          <p className="text-muted-foreground text-sm">{t("noRelations")}</p>
         ) : (
           incoming.map((r) => (
             <RelationRow

--- a/src/components/research/DataTable.tsx
+++ b/src/components/research/DataTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ChevronDown, ChevronUp } from "lucide-react";
+import { useTranslations } from "next-intl";
 import React from "react";
 
 import {
@@ -37,6 +38,7 @@ export function DataTable<TData extends { id: string }>({
   onSelectionChange,
   onRowClick,
 }: DataTableProps<TData>) {
+  const t = useTranslations("common");
   const allSelected = data.length > 0 && data.every((row) => selectedIds.includes(row.id));
   const someSelected = data.some((row) => selectedIds.includes(row.id));
 
@@ -68,7 +70,7 @@ export function DataTable<TData extends { id: string }>({
                 if (el) el.indeterminate = someSelected && !allSelected;
               }}
               onChange={handleSelectAll}
-              aria-label="Select all"
+              aria-label={t("select_all")}
               className="border-input rounded border"
             />
           </TableHead>
@@ -123,7 +125,7 @@ export function DataTable<TData extends { id: string }>({
                 checked={selectedIds.includes(row.id)}
                 onChange={(e) => handleSelectRow(row.id, e.target.checked)}
                 onClick={(e) => e.stopPropagation()}
-                aria-label={`Select row ${row.id}`}
+                aria-label={t("select_row")}
                 className="border-input rounded border"
               />
             </TableCell>

--- a/src/components/research/DataTablePagination.tsx
+++ b/src/components/research/DataTablePagination.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useTranslations } from "next-intl";
+
 import { Button } from "@/components/ui/button";
 
 interface DataTablePaginationProps {
@@ -15,11 +17,19 @@ export function DataTablePagination({
   page,
   totalPages,
   onPageChange,
-  prevLabel = "Zurück",
-  nextLabel = "Weiter",
-  pageLabel = "Seite",
+  prevLabel,
+  nextLabel,
+  pageLabel,
 }: DataTablePaginationProps) {
+  // Defaults were hardcoded German and no caller ever overrode them, so the
+  // English locale showed "Zurück/Weiter/Seite" (audit F-H4). The component now
+  // translates itself; the props remain as per-caller overrides.
+  const t = useTranslations("pagination");
   if (totalPages <= 1) return null;
+
+  const prev = prevLabel ?? t("previous");
+  const next = nextLabel ?? t("next");
+  const pageWord = pageLabel ?? t("page");
 
   return (
     <div className="flex items-center justify-center gap-4 py-2">
@@ -30,10 +40,10 @@ export function DataTablePagination({
         disabled={page <= 1}
       >
         {"< "}
-        {prevLabel}
+        {prev}
       </Button>
-      <span className="text-sm text-muted-foreground">
-        {pageLabel} {page} / {totalPages}
+      <span className="text-muted-foreground text-sm">
+        {pageWord} {page} / {totalPages}
       </span>
       <Button
         variant="outline"
@@ -41,7 +51,7 @@ export function DataTablePagination({
         onClick={() => onPageChange(page + 1)}
         disabled={page >= totalPages}
       >
-        {nextLabel}
+        {next}
         {" >"}
       </Button>
     </div>

--- a/src/components/research/EventForm.tsx
+++ b/src/components/research/EventForm.tsx
@@ -24,6 +24,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { errorCode } from "@/lib/api-error";
 import type { EventDetail, EventSummary } from "@/types/event";
 
 const formSchema = z
@@ -165,14 +166,14 @@ export function EventForm({
           error?: string;
           parent_title?: string;
         };
-        if (data.error === "DEPTH_LIMIT_EXCEEDED") {
+        if (errorCode(data) === "DEPTH_LIMIT_EXCEEDED") {
           setError("parent_id", {
             type: "manual",
             message: t("errors.depth_limit", { parent_title: data.parent_title ?? "" }),
           });
           return;
         }
-        toast.error(data.error ?? t("errors.save_failed"));
+        toast.error(t("errors.save_failed"));
         return;
       }
 
@@ -196,7 +197,7 @@ export function EventForm({
           aria-invalid={!!errors.title}
           disabled={isSubmitting}
         />
-        {errors.title && <p className="text-xs text-destructive">{errors.title.message}</p>}
+        {errors.title && <p className="text-destructive text-xs">{errors.title.message}</p>}
       </div>
 
       {/* Description */}
@@ -207,7 +208,7 @@ export function EventForm({
           rows={3}
           {...register("description")}
           disabled={isSubmitting}
-          className="flex min-h-[72px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+          className="border-input placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[72px] w-full rounded-md border bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
         />
       </div>
 
@@ -259,7 +260,7 @@ export function EventForm({
           )}
         />
         {(errors.start_year || errors.start_month || errors.start_day) && (
-          <p className="text-xs text-destructive">
+          <p className="text-destructive text-xs">
             {errors.start_year?.message ?? errors.start_month?.message ?? errors.start_day?.message}
           </p>
         )}
@@ -309,7 +310,7 @@ export function EventForm({
           )}
         />
         {(errors.end_year || errors.end_month || errors.end_day) && (
-          <p className="text-xs text-destructive">
+          <p className="text-destructive text-xs">
             {errors.end_year?.message ?? errors.end_month?.message ?? errors.end_day?.message}
           </p>
         )}
@@ -393,7 +394,7 @@ export function EventForm({
             </Command>
           </PopoverContent>
         </Popover>
-        {errors.parent_id && <p className="text-xs text-destructive">{errors.parent_id.message}</p>}
+        {errors.parent_id && <p className="text-destructive text-xs">{errors.parent_id.message}</p>}
       </div>
 
       {/* Notes */}
@@ -404,7 +405,7 @@ export function EventForm({
           rows={4}
           {...register("notes")}
           disabled={isSubmitting}
-          className="flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+          className="border-input placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-md border bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
         />
       </div>
 

--- a/src/components/research/EventForm.tsx
+++ b/src/components/research/EventForm.tsx
@@ -24,6 +24,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Textarea } from "@/components/ui/textarea";
 import { errorCode } from "@/lib/api-error";
 import type { EventDetail, EventSummary } from "@/types/event";
 
@@ -203,12 +204,12 @@ export function EventForm({
       {/* Description */}
       <div className="space-y-1">
         <Label htmlFor="description">{t("fields.description")}</Label>
-        <textarea
+        <Textarea
           id="description"
           rows={3}
           {...register("description")}
           disabled={isSubmitting}
-          className="border-input placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[72px] w-full rounded-md border bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+          className="min-h-[72px]"
         />
       </div>
 
@@ -400,13 +401,7 @@ export function EventForm({
       {/* Notes */}
       <div className="space-y-1">
         <Label htmlFor="notes">{t("fields.notes")}</Label>
-        <textarea
-          id="notes"
-          rows={4}
-          {...register("notes")}
-          disabled={isSubmitting}
-          className="border-input placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-md border bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-        />
+        <Textarea id="notes" rows={4} {...register("notes")} disabled={isSubmitting} />
       </div>
 
       {/* Actions */}

--- a/src/components/research/EventTypeSettingsTable.tsx
+++ b/src/components/research/EventTypeSettingsTable.tsx
@@ -39,6 +39,7 @@ interface EventTypeSettingsTableProps {
 
 export function EventTypeSettingsTable({ projectId }: EventTypeSettingsTableProps) {
   const t = useTranslations("event_types");
+  const tCommon = useTranslations("common");
   const params = useParams<{ locale: string }>();
   const locale = params?.locale ?? "de";
 
@@ -322,7 +323,7 @@ export function EventTypeSettingsTable({ projectId }: EventTypeSettingsTableProp
                       type="button"
                       size="sm"
                       variant="ghost"
-                      aria-label="Edit"
+                      aria-label={tCommon("edit")}
                       onClick={() =>
                         setEditState({ id: type.id, name: type.name, color: type.color })
                       }
@@ -333,7 +334,7 @@ export function EventTypeSettingsTable({ projectId }: EventTypeSettingsTableProp
                       type="button"
                       size="sm"
                       variant="ghost"
-                      aria-label="Delete"
+                      aria-label={tCommon("delete")}
                       onClick={() => handleDelete(type)}
                     >
                       <X className="h-4 w-4" />
@@ -364,7 +365,7 @@ export function EventTypeSettingsTable({ projectId }: EventTypeSettingsTableProp
             <AlertDialogDescription>{t("delete_confirm_body")}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogCancel disabled={deleting}>{tCommon("cancel")}</AlertDialogCancel>
             <AlertDialogAction
               onClick={confirmDelete}
               disabled={deleting}

--- a/src/components/research/EventTypeSettingsTable.tsx
+++ b/src/components/research/EventTypeSettingsTable.tsx
@@ -28,6 +28,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { errorCode, errorDetails, readErrorBody } from "@/lib/api-error";
 import type { EventType } from "@/types/event-type";
 
 type EditState = { id: string; name: string; color: string | null } | null;
@@ -89,8 +90,8 @@ export function EventTypeSettingsTable({ projectId }: EventTypeSettingsTableProp
         setEditState(null);
         toast.success(t("saved_toast"));
       } else {
-        const data = (await res.json().catch(() => ({}))) as { error?: string };
-        toast.error(data.error === "DUPLICATE_NAME" ? t("duplicate_error") : t("save_failed"));
+        const code = errorCode(await readErrorBody(res));
+        toast.error(code === "DUPLICATE_NAME" ? t("duplicate_error") : t("save_failed"));
       }
     } finally {
       setSaving(false);
@@ -122,10 +123,11 @@ export function EventTypeSettingsTable({ projectId }: EventTypeSettingsTableProp
         setDeleteTarget(null);
         toast.success(t("deleted_toast"));
       } else {
-        const data = (await res.json().catch(() => ({}))) as { error?: string; count?: number };
+        const body = await readErrorBody(res);
+        const details = errorDetails<{ count?: number }>(body);
         toast.error(
-          data.error === "TYPE_IN_USE"
-            ? t("in_use_toast", { count: data.count ?? 0 })
+          errorCode(body) === "IN_USE"
+            ? t("in_use_toast", { count: details?.count ?? 0 })
             : t("delete_failed"),
         );
       }
@@ -151,8 +153,8 @@ export function EventTypeSettingsTable({ projectId }: EventTypeSettingsTableProp
         setNewColor(null);
         toast.success(t("saved_toast"));
       } else {
-        const data = (await res.json().catch(() => ({}))) as { error?: string };
-        toast.error(data.error === "DUPLICATE_NAME" ? t("duplicate_error") : t("save_failed"));
+        const code = errorCode(await readErrorBody(res));
+        toast.error(code === "DUPLICATE_NAME" ? t("duplicate_error") : t("save_failed"));
       }
     } finally {
       setSavingNew(false);

--- a/src/components/research/EventsListClient.tsx
+++ b/src/components/research/EventsListClient.tsx
@@ -47,6 +47,7 @@ export function EventsListClient({
   toYear,
   topLevelOnly,
   availableTypes,
+  projectId,
 }: EventsListClientProps) {
   const t = useTranslations("events");
   const router = useRouter();
@@ -97,7 +98,7 @@ export function EventsListClient({
     const res = await fetch("/api/events/bulk", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ids: selectedIds, action: "delete" }),
+      body: JSON.stringify({ action: "delete", ids: selectedIds, project_id: projectId }),
     });
     if (res.ok) {
       const data = (await res.json()) as { deleted?: number; skipped?: number };
@@ -126,7 +127,7 @@ export function EventsListClient({
       cell: (row: EventSummary) => (
         <Link
           href={`/${locale}/events/${row.id}`}
-          className="underline hover:text-foreground"
+          className="hover:text-foreground underline"
           onClick={(e) => e.stopPropagation()}
         >
           {row.title}
@@ -178,7 +179,7 @@ export function EventsListClient({
         row.parent ? (
           <Link
             href={`/${locale}/events/${row.parent.id}`}
-            className="underline hover:text-foreground"
+            className="hover:text-foreground underline"
             onClick={(e) => e.stopPropagation()}
           >
             {row.parent.title}
@@ -202,7 +203,7 @@ export function EventsListClient({
         <p className="text-muted-foreground">{t("list.empty")}</p>
         <Link
           href={`/${locale}/events/new`}
-          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium"
         >
           {t("list.empty_action")}
         </Link>
@@ -220,7 +221,7 @@ export function EventsListClient({
         />
         {selectedIds.length > 0 && (
           <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">
+            <span className="text-muted-foreground text-sm">
               {t("bulk.selected", { count: selectedIds.length })}
             </span>
             <Button variant="destructive" size="sm" onClick={() => setBulkDeleteOpen(true)}>
@@ -240,7 +241,7 @@ export function EventsListClient({
       />
 
       {events.length === 0 ? (
-        <p className="py-8 text-center text-muted-foreground">{t("list.empty")}</p>
+        <p className="text-muted-foreground py-8 text-center">{t("list.empty")}</p>
       ) : (
         <DataTable
           data={events}
@@ -252,7 +253,7 @@ export function EventsListClient({
       )}
 
       <div className="flex items-center justify-between">
-        <p className="text-sm text-muted-foreground">
+        <p className="text-muted-foreground text-sm">
           {total} {total === 1 ? "Ereignis" : "Ereignisse"}
         </p>
         <DataTablePagination page={page} totalPages={totalPages} onPageChange={handlePageChange} />

--- a/src/components/research/EventsListClient.tsx
+++ b/src/components/research/EventsListClient.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 
 import { BulkDeleteDialog } from "@/components/research/BulkDeleteDialog";
@@ -12,6 +12,7 @@ import { DataTablePagination } from "@/components/research/DataTablePagination";
 import { DataTableSearch } from "@/components/research/DataTableSearch";
 import { EventFilters } from "@/components/research/EventFilters";
 import { Button } from "@/components/ui/button";
+import { useListUrlState } from "@/hooks/use-list-url-state";
 import { formatPartialDate } from "@/lib/date";
 import type { EventFilterState, EventSummary } from "@/types/event";
 import type { EventType } from "@/types/event-type";
@@ -51,39 +52,14 @@ export function EventsListClient({
 }: EventsListClientProps) {
   const t = useTranslations("events");
   const router = useRouter();
-  const searchParams = useSearchParams();
 
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
 
-  function buildUrl(params: Record<string, string>) {
-    const current = new URLSearchParams(searchParams.toString());
-    for (const [key, value] of Object.entries(params)) {
-      if (value) {
-        current.set(key, value);
-      } else {
-        current.delete(key);
-      }
-    }
-    return `?${current.toString()}`;
-  }
-
-  const handleSearch = useCallback(
-    (value: string) => {
-      router.push(buildUrl({ search: value, page: "1" }));
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [router, searchParams],
-  );
-
-  function handleSort(key: string) {
-    const newOrder = sort === key && order === "asc" ? "desc" : "asc";
-    router.push(buildUrl({ sort: key, order: newOrder, page: "1" }));
-  }
-
-  function handlePageChange(newPage: number) {
-    router.push(buildUrl({ page: String(newPage) }));
-  }
+  const { buildUrl, handleSearch, handleSort, handlePageChange } = useListUrlState({
+    sort,
+    order,
+  });
 
   function handleFiltersChange(filters: EventFilterState) {
     const params: Record<string, string> = { page: "1" };

--- a/src/components/research/PartialDateInput.tsx
+++ b/src/components/research/PartialDateInput.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
 
 interface PartialDateInputProps {
   yearValue: number | null;
@@ -89,7 +90,7 @@ export function PartialDateInput({
           <Label htmlFor={`${label}-month`} className="text-muted-foreground text-xs">
             {t("month")}
           </Label>
-          <select
+          <Select
             id={`${label}-month`}
             value={monthValue ?? ""}
             onChange={handleMonthChange}
@@ -102,7 +103,7 @@ export function PartialDateInput({
                 {t(`months.${m}`)}
               </option>
             ))}
-          </select>
+          </Select>
         </div>
         <div className="flex-1 space-y-1">
           <Label htmlFor={`${label}-day`} className="text-muted-foreground text-xs">

--- a/src/components/research/PartialDateInput.tsx
+++ b/src/components/research/PartialDateInput.tsx
@@ -29,6 +29,7 @@ export function PartialDateInput({
   label,
 }: PartialDateInputProps) {
   const t = useTranslations("persons.date");
+  const tCommon = useTranslations("common");
 
   function handleYearChange(e: React.ChangeEvent<HTMLInputElement>) {
     const raw = e.target.value;
@@ -69,7 +70,7 @@ export function PartialDateInput({
       <legend className="text-sm font-medium">{label}</legend>
       <div className="flex gap-2">
         <div className="flex-1 space-y-1">
-          <Label htmlFor={`${label}-year`} className="text-xs text-muted-foreground">
+          <Label htmlFor={`${label}-year`} className="text-muted-foreground text-xs">
             {t("year")}
           </Label>
           <Input
@@ -77,7 +78,7 @@ export function PartialDateInput({
             type="number"
             min={1}
             max={2100}
-            placeholder="YYYY"
+            placeholder={tCommon("year_format")}
             value={yearValue ?? ""}
             onChange={handleYearChange}
             disabled={disabled}
@@ -85,7 +86,7 @@ export function PartialDateInput({
           />
         </div>
         <div className="flex-1 space-y-1">
-          <Label htmlFor={`${label}-month`} className="text-xs text-muted-foreground">
+          <Label htmlFor={`${label}-month`} className="text-muted-foreground text-xs">
             {t("month")}
           </Label>
           <select
@@ -93,7 +94,7 @@ export function PartialDateInput({
             value={monthValue ?? ""}
             onChange={handleMonthChange}
             disabled={monthDisabled}
-            className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+            className="border-input focus-visible:ring-ring flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
           >
             <option value="">{t("no_month")}</option>
             {MONTH_KEYS.map((m) => (
@@ -104,7 +105,7 @@ export function PartialDateInput({
           </select>
         </div>
         <div className="flex-1 space-y-1">
-          <Label htmlFor={`${label}-day`} className="text-xs text-muted-foreground">
+          <Label htmlFor={`${label}-day`} className="text-muted-foreground text-xs">
             {t("day")}
           </Label>
           <Input

--- a/src/components/research/PersonForm.tsx
+++ b/src/components/research/PersonForm.tsx
@@ -12,6 +12,7 @@ import { PersonNameList } from "@/components/research/PersonNameList";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import { type PersonFormValues, buildPersonFormSchema } from "@/lib/schemas/person";
 import type { PersonDetail } from "@/types/person";
 
@@ -251,13 +252,7 @@ export function PersonForm({ mode, initial, projectId, onSuccess, onCancel }: Pe
       {/* Notes */}
       <div className="space-y-1">
         <Label htmlFor="notes">{t("fields.notes")}</Label>
-        <textarea
-          id="notes"
-          rows={4}
-          {...register("notes")}
-          disabled={isSubmitting}
-          className="border-input placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-md border bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-        />
+        <Textarea id="notes" rows={4} {...register("notes")} disabled={isSubmitting} />
       </div>
 
       {/* Actions */}

--- a/src/components/research/PersonForm.tsx
+++ b/src/components/research/PersonForm.tsx
@@ -3,9 +3,8 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { z } from "zod";
 
 import { CertaintySelector } from "@/components/research/CertaintySelector";
 import { PartialDateInput } from "@/components/research/PartialDateInput";
@@ -13,34 +12,8 @@ import { PersonNameList } from "@/components/research/PersonNameList";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { type PersonFormValues, buildPersonFormSchema } from "@/lib/schemas/person";
 import type { PersonDetail } from "@/types/person";
-
-const formSchema = z.object({
-  first_name: z.string().optional(),
-  last_name: z.string().optional(),
-  birth_year: z.number().int().min(1).max(2100).optional().nullable(),
-  birth_month: z.number().int().min(1).max(12).optional().nullable(),
-  birth_day: z.number().int().min(1).max(31).optional().nullable(),
-  birth_date_certainty: z.enum(["CERTAIN", "PROBABLE", "POSSIBLE", "UNKNOWN"]),
-  birth_place: z.string().optional(),
-  death_year: z.number().int().min(1).max(2100).optional().nullable(),
-  death_month: z.number().int().min(1).max(12).optional().nullable(),
-  death_day: z.number().int().min(1).max(31).optional().nullable(),
-  death_date_certainty: z.enum(["CERTAIN", "PROBABLE", "POSSIBLE", "UNKNOWN"]),
-  death_place: z.string().optional(),
-  notes: z.string().optional(),
-  names: z
-    .array(
-      z.object({
-        name: z.string().min(1),
-        language: z.string().nullable().optional(),
-        is_primary: z.boolean().optional(),
-      }),
-    )
-    .optional(),
-});
-
-type FormValues = z.infer<typeof formSchema>;
 
 interface PersonFormProps {
   mode: "create" | "edit";
@@ -54,12 +27,16 @@ export function PersonForm({ mode, initial, projectId, onSuccess, onCancel }: Pe
   const t = useTranslations("persons");
   const [serverError, setServerError] = useState<string | null>(null);
 
+  // Built inside the component so Zod messages resolve through t() — the same
+  // convention the auth forms use. Shares the server's rules (audit X-H-c).
+  const formSchema = useMemo(() => buildPersonFormSchema((key) => t(`errors.${key}`)), [t]);
+
   const {
     register,
     handleSubmit,
     control,
     formState: { errors, isSubmitting },
-  } = useForm<FormValues>({
+  } = useForm<PersonFormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
       first_name: initial?.first_name ?? "",
@@ -79,7 +56,7 @@ export function PersonForm({ mode, initial, projectId, onSuccess, onCancel }: Pe
     },
   });
 
-  async function onSubmit(values: FormValues) {
+  async function onSubmit(values: PersonFormValues) {
     setServerError(null);
     try {
       const url = mode === "create" ? "/api/persons" : `/api/persons/${initial?.id}`;
@@ -118,7 +95,7 @@ export function PersonForm({ mode, initial, projectId, onSuccess, onCancel }: Pe
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
       {serverError && (
-        <div role="alert" className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+        <div role="alert" className="bg-destructive/10 text-destructive rounded-md p-3 text-sm">
           {serverError}
         </div>
       )}
@@ -134,7 +111,7 @@ export function PersonForm({ mode, initial, projectId, onSuccess, onCancel }: Pe
             aria-invalid={!!errors.first_name}
           />
           {errors.first_name && (
-            <p className="text-xs text-destructive">{errors.first_name.message}</p>
+            <p className="text-destructive text-xs">{errors.first_name.message}</p>
           )}
         </div>
         <div className="space-y-1">
@@ -146,7 +123,7 @@ export function PersonForm({ mode, initial, projectId, onSuccess, onCancel }: Pe
             aria-invalid={!!errors.last_name}
           />
           {errors.last_name && (
-            <p className="text-xs text-destructive">{errors.last_name.message}</p>
+            <p className="text-destructive text-xs">{errors.last_name.message}</p>
           )}
         </div>
       </div>
@@ -280,7 +257,7 @@ export function PersonForm({ mode, initial, projectId, onSuccess, onCancel }: Pe
           rows={4}
           {...register("notes")}
           disabled={isSubmitting}
-          className="flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+          className="border-input placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-md border bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
         />
       </div>
 

--- a/src/components/research/PersonForm.tsx
+++ b/src/components/research/PersonForm.tsx
@@ -80,8 +80,7 @@ export function PersonForm({ mode, initial, projectId, onSuccess, onCancel }: Pe
       });
 
       if (!res.ok) {
-        const data = (await res.json().catch(() => ({}))) as { error?: string };
-        setServerError(data.error ?? t("errors.save_failed"));
+        setServerError(t("errors.save_failed"));
         return;
       }
 

--- a/src/components/research/PersonsListClient.tsx
+++ b/src/components/research/PersonsListClient.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 
 import { BulkDeleteDialog } from "@/components/research/BulkDeleteDialog";
@@ -11,6 +11,7 @@ import { DataTable } from "@/components/research/DataTable";
 import { DataTablePagination } from "@/components/research/DataTablePagination";
 import { DataTableSearch } from "@/components/research/DataTableSearch";
 import { Button } from "@/components/ui/button";
+import { useListUrlState } from "@/hooks/use-list-url-state";
 import { formatPartialDate } from "@/lib/date";
 import type { PersonSummary } from "@/types/person";
 
@@ -39,39 +40,14 @@ export function PersonsListClient({
 }: PersonsListClientProps) {
   const t = useTranslations("persons");
   const router = useRouter();
-  const searchParams = useSearchParams();
 
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
 
-  function buildUrl(params: Record<string, string>) {
-    const current = new URLSearchParams(searchParams.toString());
-    for (const [key, value] of Object.entries(params)) {
-      if (value) {
-        current.set(key, value);
-      } else {
-        current.delete(key);
-      }
-    }
-    return `?${current.toString()}`;
-  }
-
-  const handleSearch = useCallback(
-    (value: string) => {
-      router.push(buildUrl({ search: value, page: "1" }));
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [router, searchParams],
-  );
-
-  function handleSort(key: string) {
-    const newOrder = sort === key && order === "asc" ? "desc" : "asc";
-    router.push(buildUrl({ sort: key, order: newOrder, page: "1" }));
-  }
-
-  function handlePageChange(newPage: number) {
-    router.push(buildUrl({ page: String(newPage) }));
-  }
+  const { handleSearch, handleSort, handlePageChange } = useListUrlState({
+    sort,
+    order,
+  });
 
   async function handleBulkDelete() {
     const res = await fetch("/api/persons/bulk", {

--- a/src/components/research/PersonsListClient.tsx
+++ b/src/components/research/PersonsListClient.tsx
@@ -35,6 +35,7 @@ export function PersonsListClient({
   search,
   sort,
   order,
+  projectId,
 }: PersonsListClientProps) {
   const t = useTranslations("persons");
   const router = useRouter();
@@ -76,7 +77,7 @@ export function PersonsListClient({
     const res = await fetch("/api/persons/bulk", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ids: selectedIds, action: "delete" }),
+      body: JSON.stringify({ action: "delete", ids: selectedIds, project_id: projectId }),
     });
     if (res.ok) {
       toast.success(t("bulk.deleted_toast", { count: selectedIds.length }));

--- a/src/components/research/SourceForm.tsx
+++ b/src/components/research/SourceForm.tsx
@@ -21,6 +21,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Textarea } from "@/components/ui/textarea";
 import { SOURCE_TYPE_SUGGESTIONS } from "@/lib/source-types";
 import type { SourceDetail, SourceReliability } from "@/types/source";
 
@@ -306,13 +307,7 @@ export function SourceForm({ projectId, locale, initial }: SourceFormProps) {
       {/* Notes — full width */}
       <div className="space-y-1">
         <Label htmlFor="notes">{t("field_notes")}</Label>
-        <textarea
-          id="notes"
-          rows={4}
-          {...register("notes")}
-          disabled={isSubmitting}
-          className="border-input placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-md border bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-        />
+        <Textarea id="notes" rows={4} {...register("notes")} disabled={isSubmitting} />
       </div>
 
       {/* Actions */}

--- a/src/components/research/SourceForm.tsx
+++ b/src/components/research/SourceForm.tsx
@@ -106,8 +106,7 @@ export function SourceForm({ projectId, locale, initial }: SourceFormProps) {
       });
 
       if (!res.ok) {
-        const data = (await res.json().catch(() => ({}))) as { error?: string };
-        toast.error(data.error ?? t("errors.save_failed"));
+        toast.error(t("errors.save_failed"));
         return;
       }
 
@@ -135,7 +134,7 @@ export function SourceForm({ projectId, locale, initial }: SourceFormProps) {
               disabled={isSubmitting}
             />
             {errors.title && (
-              <p className="text-xs text-destructive">{t("errors.title_required")}</p>
+              <p className="text-destructive text-xs">{t("errors.title_required")}</p>
             )}
           </div>
 
@@ -206,16 +205,14 @@ export function SourceForm({ projectId, locale, initial }: SourceFormProps) {
                     </PopoverContent>
                   </Popover>
                   {field.value && (
-                    <span className="inline-block rounded bg-muted px-2 py-0.5 text-xs">
+                    <span className="bg-muted inline-block rounded px-2 py-0.5 text-xs">
                       {safeTypeLabel(field.value)}
                     </span>
                   )}
                 </div>
               )}
             />
-            {errors.type && (
-              <p className="text-xs text-destructive">{t("errors.type_required")}</p>
-            )}
+            {errors.type && <p className="text-destructive text-xs">{t("errors.type_required")}</p>}
           </div>
 
           {/* Author */}
@@ -240,7 +237,7 @@ export function SourceForm({ projectId, locale, initial }: SourceFormProps) {
                       disabled={isSubmitting}
                       onClick={() => field.onChange(r)}
                       className={[
-                        "rounded-md border px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+                        "focus-visible:ring-ring rounded-md border px-3 py-1 text-xs font-medium transition-colors focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
                         field.value === r
                           ? "border-primary bg-primary text-primary-foreground"
                           : "border-input bg-background text-foreground hover:bg-accent hover:text-accent-foreground",
@@ -272,7 +269,12 @@ export function SourceForm({ projectId, locale, initial }: SourceFormProps) {
           {/* Repository */}
           <div className="space-y-1">
             <Label htmlFor="repository">{t("field_repository")}</Label>
-            <Input id="repository" type="text" {...register("repository")} disabled={isSubmitting} />
+            <Input
+              id="repository"
+              type="text"
+              {...register("repository")}
+              disabled={isSubmitting}
+            />
           </div>
 
           {/* Call Number */}
@@ -296,9 +298,7 @@ export function SourceForm({ projectId, locale, initial }: SourceFormProps) {
               aria-invalid={!!errors.url}
               disabled={isSubmitting}
             />
-            {errors.url && (
-              <p className="text-xs text-destructive">{t("errors.invalid_url")}</p>
-            )}
+            {errors.url && <p className="text-destructive text-xs">{t("errors.invalid_url")}</p>}
           </div>
         </div>
       </div>
@@ -311,7 +311,7 @@ export function SourceForm({ projectId, locale, initial }: SourceFormProps) {
           rows={4}
           {...register("notes")}
           disabled={isSubmitting}
-          className="flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+          className="border-input placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-md border bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
         />
       </div>
 
@@ -330,7 +330,6 @@ export function SourceForm({ projectId, locale, initial }: SourceFormProps) {
           {mode === "create" ? t("save") : t("save_changes")}
         </Button>
       </div>
-
     </form>
   );
 }

--- a/src/components/research/SourceTable.tsx
+++ b/src/components/research/SourceTable.tsx
@@ -14,6 +14,7 @@ import { DataTableSearch } from "@/components/research/DataTableSearch";
 import { DeleteSourceButton } from "@/components/research/DeleteSourceButton";
 import { ReliabilityBadge } from "@/components/research/ReliabilityBadge";
 import { Button } from "@/components/ui/button";
+import { Select } from "@/components/ui/select";
 import { SOURCE_TYPE_SUGGESTIONS } from "@/lib/source-types";
 import type { SourceReliability, SourceSummary } from "@/types/source";
 
@@ -195,10 +196,10 @@ export function SourceTable({
           />
 
           {/* Type filter */}
-          <select
+          <Select
             value={type}
             onChange={(e) => handleTypeChange(e.target.value)}
-            className="border-input bg-background rounded-md border px-3 py-1.5 text-sm"
+            className="h-auto w-auto py-1.5"
           >
             <option value="">{t("all_types")}</option>
             {SOURCE_TYPE_SUGGESTIONS.map((s) => (
@@ -206,7 +207,7 @@ export function SourceTable({
                 {s}
               </option>
             ))}
-          </select>
+          </Select>
 
           {/* Reliability filter */}
           <div className="flex items-center gap-1">

--- a/src/components/research/SourceTable.tsx
+++ b/src/components/research/SourceTable.tsx
@@ -2,9 +2,9 @@
 
 import { Pencil } from "lucide-react";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 
 import { BulkDeleteDialog } from "@/components/research/BulkDeleteDialog";
@@ -15,6 +15,7 @@ import { DeleteSourceButton } from "@/components/research/DeleteSourceButton";
 import { ReliabilityBadge } from "@/components/research/ReliabilityBadge";
 import { Button } from "@/components/ui/button";
 import { Select } from "@/components/ui/select";
+import { useListUrlState } from "@/hooks/use-list-url-state";
 import { SOURCE_TYPE_SUGGESTIONS } from "@/lib/source-types";
 import type { SourceReliability, SourceSummary } from "@/types/source";
 
@@ -49,39 +50,14 @@ export function SourceTable({
 }: SourceTableProps) {
   const t = useTranslations("sources");
   const router = useRouter();
-  const searchParams = useSearchParams();
 
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
 
-  function buildUrl(params: Record<string, string>) {
-    const current = new URLSearchParams(searchParams.toString());
-    for (const [key, value] of Object.entries(params)) {
-      if (value) {
-        current.set(key, value);
-      } else {
-        current.delete(key);
-      }
-    }
-    return `?${current.toString()}`;
-  }
-
-  const handleSearch = useCallback(
-    (value: string) => {
-      router.push(buildUrl({ search: value, page: "1" }));
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [router, searchParams],
-  );
-
-  function handleSort(key: string) {
-    const newOrder = sort === key && order === "asc" ? "desc" : "asc";
-    router.push(buildUrl({ sort: key, order: newOrder, page: "1" }));
-  }
-
-  function handlePageChange(newPage: number) {
-    router.push(buildUrl({ page: String(newPage) }));
-  }
+  const { buildUrl, handleSearch, handleSort, handlePageChange } = useListUrlState({
+    sort,
+    order,
+  });
 
   function handleTypeChange(value: string) {
     router.push(buildUrl({ type: value, page: "1" }));

--- a/src/components/research/SourceTable.tsx
+++ b/src/components/research/SourceTable.tsx
@@ -97,7 +97,7 @@ export function SourceTable({
     const res = await fetch("/api/sources/bulk", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ids: selectedIds, project_id: projectId }),
+      body: JSON.stringify({ action: "delete", ids: selectedIds, project_id: projectId }),
     });
     if (res.ok) {
       toast.success(t("bulk.deleted_toast", { count: selectedIds.length }));

--- a/src/components/shell/sidebar.tsx
+++ b/src/components/shell/sidebar.tsx
@@ -24,6 +24,7 @@ interface SidebarProps {
 
 export function Sidebar({ isOpen }: SidebarProps) {
   const t = useTranslations("shell.nav");
+  const tCommon = useTranslations("common");
   const params = useParams<{ locale: string }>();
   const locale = params?.locale ?? "de";
 
@@ -52,7 +53,7 @@ export function Sidebar({ isOpen }: SidebarProps) {
         <span
           key={key}
           className={cn(
-            "flex cursor-not-allowed items-center gap-3 rounded-md px-2 py-2 text-sm text-muted-foreground opacity-50 pointer-events-none",
+            "text-muted-foreground pointer-events-none flex cursor-not-allowed items-center gap-3 rounded-md px-2 py-2 text-sm opacity-50",
             !isOpen && "justify-center",
           )}
           title={!isOpen ? label : undefined}
@@ -70,7 +71,7 @@ export function Sidebar({ isOpen }: SidebarProps) {
         key={key}
         href={href}
         className={cn(
-          "flex items-center gap-3 rounded-md px-2 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground",
+          "text-muted-foreground hover:bg-accent hover:text-accent-foreground flex items-center gap-3 rounded-md px-2 py-2 text-sm transition-colors",
           !isOpen && "justify-center",
         )}
         title={!isOpen ? label : undefined}
@@ -85,14 +86,16 @@ export function Sidebar({ isOpen }: SidebarProps) {
   return (
     <aside
       className={cn(
-        "fixed bottom-0 left-0 top-14 z-30 flex flex-col border-r bg-background transition-all duration-200",
+        "bg-background fixed top-14 bottom-0 left-0 z-30 flex flex-col border-r transition-all duration-200",
         isOpen ? "w-56" : "w-12",
       )}
-      aria-label="Main navigation"
+      aria-label={tCommon("main_navigation")}
     >
       <nav className="flex h-full flex-col p-2" role="navigation">
         <div className="flex-1 space-y-1">
-          {primaryNavItems.map(({ key, icon, label, disabled }) => navLink(key, icon, label, disabled))}
+          {primaryNavItems.map(({ key, icon, label, disabled }) =>
+            navLink(key, icon, label, disabled),
+          )}
         </div>
         <div className="mt-auto">
           <Separator className="mb-2" />

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement>;
+
+/**
+ * Native select styled to match Input/Textarea (audit F-M9).
+ *
+ * Five call sites hand-rolled this with four different class strings. This is a
+ * plain <select> rather than a Radix listbox on purpose: the existing usages are
+ * native selects, and swapping in a custom widget would change keyboard and
+ * screen-reader behaviour well beyond the scope of removing duplication.
+ */
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <select
+        className={cn(
+          "border-input bg-background focus-visible:ring-ring flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-sm focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </select>
+    );
+  },
+);
+Select.displayName = "Select";
+
+export { Select };

--- a/src/components/ui/textarea.test.tsx
+++ b/src/components/ui/textarea.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+
+import { Select } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+describe("Textarea", () => {
+  it("renders a textarea and forwards props", () => {
+    render(<Textarea aria-label="Notes" placeholder="Type here" defaultValue="hello" />);
+    const el = screen.getByLabelText("Notes");
+    expect(el.tagName).toBe("TEXTAREA");
+    expect(el).toHaveAttribute("placeholder", "Type here");
+    expect(el).toHaveValue("hello");
+  });
+
+  it("applies the shared default height", () => {
+    render(<Textarea aria-label="Notes" />);
+    expect(screen.getByLabelText("Notes").className).toContain("min-h-[80px]");
+  });
+
+  it("merges a caller override instead of forcing a forked class string", () => {
+    render(<Textarea aria-label="Notes" className="min-h-[72px]" />);
+    const cls = screen.getByLabelText("Notes").className;
+    expect(cls).toContain("min-h-[72px]");
+    // the rest of the shared styling survives the override
+    expect(cls).toContain("rounded-md");
+  });
+
+  it("forwards a ref", () => {
+    const ref = createRef<HTMLTextAreaElement>();
+    render(<Textarea aria-label="Notes" ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLTextAreaElement);
+  });
+});
+
+describe("Select", () => {
+  it("renders a native select with its options", () => {
+    render(
+      <Select aria-label="Type">
+        <option value="a">Alpha</option>
+        <option value="b">Beta</option>
+      </Select>,
+    );
+    const el = screen.getByLabelText("Type");
+    expect(el.tagName).toBe("SELECT");
+    expect(screen.getByRole("option", { name: "Alpha" })).toBeInTheDocument();
+  });
+
+  it("honours value and disabled", () => {
+    render(
+      <Select aria-label="Type" defaultValue="b" disabled>
+        <option value="a">Alpha</option>
+        <option value="b">Beta</option>
+      </Select>,
+    );
+    const el = screen.getByLabelText("Type");
+    expect(el).toHaveValue("b");
+    expect(el).toBeDisabled();
+  });
+
+  it("merges caller classes", () => {
+    render(<Select aria-label="Type" className="w-auto" />);
+    const cls = screen.getByLabelText("Type").className;
+    expect(cls).toContain("w-auto");
+    expect(cls).toContain("border-input");
+  });
+
+  it("forwards a ref", () => {
+    const ref = createRef<HTMLSelectElement>();
+    render(<Select aria-label="Type" ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLSelectElement);
+  });
+});

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+/**
+ * Multi-line text input (audit F-M9).
+ *
+ * The ~180-character class string was copy-pasted across five forms and had
+ * already drifted — four used min-h-[80px] and one min-h-[72px]. Callers that
+ * genuinely need a different height pass `className="min-h-[…]"`, which merges
+ * via cn() instead of forking the whole string.
+ */
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "border-input placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-md border bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/src/hooks/use-list-url-state.test.ts
+++ b/src/hooks/use-list-url-state.test.ts
@@ -1,0 +1,85 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPush = vi.fn();
+let currentParams = new URLSearchParams("");
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => currentParams,
+}));
+
+const { useListUrlState } = await import("@/hooks/use-list-url-state");
+
+describe("useListUrlState", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    currentParams = new URLSearchParams("");
+  });
+
+  it("preserves existing params when setting a new one", () => {
+    currentParams = new URLSearchParams("search=ada&sort=last_name");
+    const { result } = renderHook(() => useListUrlState());
+    const url = new URLSearchParams(result.current.buildUrl({ page: "3" }).slice(1));
+    expect(url.get("search")).toBe("ada");
+    expect(url.get("sort")).toBe("last_name");
+    expect(url.get("page")).toBe("3");
+  });
+
+  it("deletes a key when given an empty value", () => {
+    currentParams = new URLSearchParams("search=ada&page=2");
+    const { result } = renderHook(() => useListUrlState());
+    const url = new URLSearchParams(result.current.buildUrl({ search: "" }).slice(1));
+    expect(url.has("search")).toBe(false);
+    expect(url.get("page")).toBe("2");
+  });
+
+  it("resets to page 1 on search", () => {
+    currentParams = new URLSearchParams("page=5");
+    const { result } = renderHook(() => useListUrlState());
+    result.current.handleSearch("humboldt");
+    const url = new URLSearchParams((mockPush.mock.calls[0]?.[0] as string).slice(1));
+    expect(url.get("search")).toBe("humboldt");
+    expect(url.get("page")).toBe("1");
+  });
+
+  it("sorts ascending when clicking a new column", () => {
+    const { result } = renderHook(() => useListUrlState({ sort: "last_name", order: "asc" }));
+    result.current.handleSort("first_name");
+    const url = new URLSearchParams((mockPush.mock.calls[0]?.[0] as string).slice(1));
+    expect(url.get("sort")).toBe("first_name");
+    expect(url.get("order")).toBe("asc");
+  });
+
+  it("toggles to desc when re-clicking the active ascending column", () => {
+    const { result } = renderHook(() => useListUrlState({ sort: "last_name", order: "asc" }));
+    result.current.handleSort("last_name");
+    const url = new URLSearchParams((mockPush.mock.calls[0]?.[0] as string).slice(1));
+    expect(url.get("order")).toBe("desc");
+  });
+
+  it("toggles back to asc when re-clicking the active descending column", () => {
+    const { result } = renderHook(() => useListUrlState({ sort: "last_name", order: "desc" }));
+    result.current.handleSort("last_name");
+    const url = new URLSearchParams((mockPush.mock.calls[0]?.[0] as string).slice(1));
+    expect(url.get("order")).toBe("asc");
+  });
+
+  it("resets to page 1 when sorting", () => {
+    currentParams = new URLSearchParams("page=4");
+    const { result } = renderHook(() => useListUrlState({ sort: "last_name", order: "asc" }));
+    result.current.handleSort("first_name");
+    const url = new URLSearchParams((mockPush.mock.calls[0]?.[0] as string).slice(1));
+    expect(url.get("page")).toBe("1");
+  });
+
+  it("changes page without disturbing filters", () => {
+    currentParams = new URLSearchParams("search=ada&sort=last_name&order=desc");
+    const { result } = renderHook(() => useListUrlState());
+    result.current.handlePageChange(2);
+    const url = new URLSearchParams((mockPush.mock.calls[0]?.[0] as string).slice(1));
+    expect(url.get("page")).toBe("2");
+    expect(url.get("search")).toBe("ada");
+    expect(url.get("order")).toBe("desc");
+  });
+});

--- a/src/hooks/use-list-url-state.ts
+++ b/src/hooks/use-list-url-state.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useMemo } from "react";
+
+interface UseListUrlStateOptions {
+  /** Current sort key, used to decide whether a sort click toggles direction. */
+  sort?: string | undefined;
+  /** Current sort direction. */
+  order?: string | undefined;
+}
+
+export interface ListUrlState {
+  /** Builds a query string from the current params plus `params`. Empty values delete the key. */
+  buildUrl: (params: Record<string, string>) => string;
+  /** Navigates with `params` merged into the current query. */
+  push: (params: Record<string, string>) => void;
+  /** Sets `search` and returns to page 1. */
+  handleSearch: (value: string) => void;
+  /** Toggles asc/desc when re-clicking the active column, else sorts ascending. Resets to page 1. */
+  handleSort: (key: string) => void;
+  /** Navigates to `newPage`, preserving all other params. */
+  handlePageChange: (newPage: number) => void;
+}
+
+/**
+ * URL-param list state shared by the entity list clients (audit F-M2 / X-M4).
+ *
+ * buildUrl, handleSearch, handleSort and handlePageChange were duplicated
+ * verbatim across PersonsListClient, EventsListClient and SourceTable — each
+ * carrying the same `eslint-disable react-hooks/exhaustive-deps`, which the
+ * audit called out as a sign the dependencies were wrong in all three. They are
+ * correct here: every callback depends only on the router, the current params,
+ * and the current sort, all of which are in the dependency arrays.
+ */
+export function useListUrlState({ sort, order }: UseListUrlStateOptions = {}): ListUrlState {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const search = searchParams.toString();
+
+  const buildUrl = useCallback(
+    (params: Record<string, string>) => {
+      const current = new URLSearchParams(search);
+      for (const [key, value] of Object.entries(params)) {
+        if (value) {
+          current.set(key, value);
+        } else {
+          current.delete(key);
+        }
+      }
+      return `?${current.toString()}`;
+    },
+    [search],
+  );
+
+  const push = useCallback(
+    (params: Record<string, string>) => {
+      router.push(buildUrl(params));
+    },
+    [router, buildUrl],
+  );
+
+  const handleSearch = useCallback(
+    (value: string) => {
+      push({ search: value, page: "1" });
+    },
+    [push],
+  );
+
+  const handleSort = useCallback(
+    (key: string) => {
+      const newOrder = sort === key && order === "asc" ? "desc" : "asc";
+      push({ sort: key, order: newOrder, page: "1" });
+    },
+    [push, sort, order],
+  );
+
+  const handlePageChange = useCallback(
+    (newPage: number) => {
+      push({ page: String(newPage) });
+    },
+    [push],
+  );
+
+  return useMemo(
+    () => ({ buildUrl, push, handleSearch, handleSort, handlePageChange }),
+    [buildUrl, push, handleSearch, handleSort, handlePageChange],
+  );
+}

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -1,0 +1,50 @@
+import type { ErrorCode } from "@/lib/api";
+
+/**
+ * Client-side reader for the unified error envelope (audit A-H4).
+ *
+ * Clients used to branch on `data.error` as a bare string, which meant
+ * string-matching prose or i18n keys — and when no branch matched, several call
+ * sites rendered the raw backend value to the user. Codes are the only thing
+ * clients should key off; the copy lives in `messages/*.json`.
+ */
+export interface ApiErrorPayload {
+  error?: { code?: string; message?: string; details?: unknown };
+}
+
+/** Extracts the machine-readable code from a failed response body. */
+export function errorCode(body: unknown): string | undefined {
+  if (typeof body !== "object" || body === null) return undefined;
+  const { error } = body as ApiErrorPayload;
+  if (typeof error !== "object" || error === null) return undefined;
+  return typeof error.code === "string" ? error.code : undefined;
+}
+
+/** Extracts `error.details` for codes that carry structured context. */
+export function errorDetails<T = unknown>(body: unknown): T | undefined {
+  if (typeof body !== "object" || body === null) return undefined;
+  const { error } = body as ApiErrorPayload;
+  if (typeof error !== "object" || error === null) return undefined;
+  return error.details as T | undefined;
+}
+
+/** Reads the response body without throwing on a non-JSON payload. */
+export async function readErrorBody(res: Response): Promise<unknown> {
+  return res.json().catch(() => ({}));
+}
+
+/**
+ * Resolves an error code to translated copy.
+ *
+ * `map` gives a caller-specific code -> translation-key mapping; anything
+ * unmapped falls back to `fallbackKey` so a user never sees a raw code.
+ */
+export function translateErrorCode(
+  code: string | undefined,
+  t: (key: string) => string,
+  map: Partial<Record<ErrorCode | string, string>>,
+  fallbackKey: string,
+): string {
+  const key = code ? map[code] : undefined;
+  return t(key ?? fallbackKey);
+}

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -45,35 +45,50 @@ describe("json", () => {
 });
 
 describe("jsonError", () => {
-  it("emits { error } with the given status", async () => {
-    const res = jsonError(418, "TEAPOT");
-    expect(res.status).toBe(418);
-    expect(await res.json()).toEqual({ error: "TEAPOT" });
+  it("wraps the code in the unified envelope", async () => {
+    const res = jsonError(409, "IN_USE");
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: { code: "IN_USE" } });
   });
 
-  it("merges extra fields alongside error", async () => {
-    const res = jsonError(409, "IN_USE", { count: 5 });
-    expect(await res.json()).toEqual({ error: "IN_USE", count: 5 });
+  it("omits message and details when not supplied", async () => {
+    const body = (await jsonError(403, "FORBIDDEN").json()) as Record<string, unknown>;
+    expect(body).toEqual({ error: { code: "FORBIDDEN" } });
+    expect(Object.keys(body["error"] as object)).toEqual(["code"]);
+  });
+
+  it("carries structured details under error.details", async () => {
+    const res = jsonError(409, "IN_USE", { details: { count: 5 } });
+    expect(await res.json()).toEqual({ error: { code: "IN_USE", details: { count: 5 } } });
+  });
+
+  it("carries a developer-facing message under error.message", async () => {
+    const res = jsonError(422, "INVALID_REFERENCE", { message: "Parent event not found" });
+    expect(await res.json()).toEqual({
+      error: { code: "INVALID_REFERENCE", message: "Parent event not found" },
+    });
   });
 });
 
 describe("standard error shorthands", () => {
-  it("unauthorized is 401 Unauthorized", async () => {
+  it("unauthorized is 401 UNAUTHORIZED", async () => {
     const res = unauthorized();
     expect(res.status).toBe(401);
-    expect(await res.json()).toEqual({ error: "Unauthorized" });
+    expect(await res.json()).toEqual({ error: { code: "UNAUTHORIZED" } });
   });
 
-  it("forbidden is 403 Forbidden", async () => {
+  it("forbidden is 403 FORBIDDEN", async () => {
     const res = forbidden();
     expect(res.status).toBe(403);
-    expect(await res.json()).toEqual({ error: "Forbidden" });
+    expect(await res.json()).toEqual({ error: { code: "FORBIDDEN" } });
   });
 
-  it("notFoundError defaults to 404 Not found and accepts an override", async () => {
+  it("notFoundError defaults to NOT_FOUND and accepts a more specific code", async () => {
     expect(notFoundError().status).toBe(404);
-    expect(await notFoundError().json()).toEqual({ error: "Not found" });
-    expect(await notFoundError("ENTITY_NOT_FOUND").json()).toEqual({ error: "ENTITY_NOT_FOUND" });
+    expect(await notFoundError().json()).toEqual({ error: { code: "NOT_FOUND" } });
+    expect(await notFoundError("ENTITY_NOT_FOUND").json()).toEqual({
+      error: { code: "ENTITY_NOT_FOUND" },
+    });
   });
 });
 
@@ -89,7 +104,7 @@ describe("parseJsonBody", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.response.status).toBe(400);
-      expect(await result.response.json()).toEqual({ error: "Invalid JSON" });
+      expect(await result.response.json()).toEqual({ error: { code: "INVALID_JSON" } });
     }
   });
 });
@@ -108,9 +123,11 @@ describe("validateBody", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.response.status).toBe(400);
-      const body = (await result.response.json()) as { error: string; details: unknown };
-      expect(body.error).toBe("Validation failed");
-      expect(body.details).toBeDefined();
+      const body = (await result.response.json()) as {
+        error: { code: string; details: unknown };
+      };
+      expect(body.error.code).toBe("VALIDATION_FAILED");
+      expect(body.error.details).toBeDefined();
     }
   });
 });

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+const mockUserProjectFindFirst = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    userProject: { findFirst: mockUserProjectFindFirst },
+  },
+}));
+
+const {
+  forbidden,
+  json,
+  jsonError,
+  notFoundError,
+  parseJsonBody,
+  requireProjectMembership,
+  unauthorized,
+  validateBody,
+} = await import("@/lib/api");
+
+function makeRequest(body: string): Request {
+  return new Request("http://localhost/api/x", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+}
+
+describe("json", () => {
+  it("defaults to 200 and always sets Cache-Control: no-store", async () => {
+    const res = json({ ok: true });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("honours an explicit status and merges extra headers", () => {
+    const res = json({ id: "1" }, { status: 201, headers: { "X-Test": "yes" } });
+    expect(res.status).toBe(201);
+    expect(res.headers.get("X-Test")).toBe("yes");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+});
+
+describe("jsonError", () => {
+  it("emits { error } with the given status", async () => {
+    const res = jsonError(418, "TEAPOT");
+    expect(res.status).toBe(418);
+    expect(await res.json()).toEqual({ error: "TEAPOT" });
+  });
+
+  it("merges extra fields alongside error", async () => {
+    const res = jsonError(409, "IN_USE", { count: 5 });
+    expect(await res.json()).toEqual({ error: "IN_USE", count: 5 });
+  });
+});
+
+describe("standard error shorthands", () => {
+  it("unauthorized is 401 Unauthorized", async () => {
+    const res = unauthorized();
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  it("forbidden is 403 Forbidden", async () => {
+    const res = forbidden();
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Forbidden" });
+  });
+
+  it("notFoundError defaults to 404 Not found and accepts an override", async () => {
+    expect(notFoundError().status).toBe(404);
+    expect(await notFoundError().json()).toEqual({ error: "Not found" });
+    expect(await notFoundError("ENTITY_NOT_FOUND").json()).toEqual({ error: "ENTITY_NOT_FOUND" });
+  });
+});
+
+describe("parseJsonBody", () => {
+  it("returns the parsed body on valid JSON", async () => {
+    const result = await parseJsonBody(makeRequest('{"name":"Ada"}'));
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data).toEqual({ name: "Ada" });
+  });
+
+  it("returns a 400 Invalid JSON response on malformed JSON", async () => {
+    const result = await parseJsonBody(makeRequest("{not json"));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(400);
+      expect(await result.response.json()).toEqual({ error: "Invalid JSON" });
+    }
+  });
+});
+
+describe("validateBody", () => {
+  const schema = z.object({ name: z.string().min(1) });
+
+  it("returns typed data when valid", () => {
+    const result = validateBody(schema, { name: "Ada" });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.name).toBe("Ada");
+  });
+
+  it("returns 400 with flattened details when invalid", async () => {
+    const result = validateBody(schema, { name: "" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(400);
+      const body = (await result.response.json()) as { error: string; details: unknown };
+      expect(body.error).toBe("Validation failed");
+      expect(body.details).toBeDefined();
+    }
+  });
+});
+
+describe("requireProjectMembership", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns true when a membership row exists", async () => {
+    mockUserProjectFindFirst.mockResolvedValue({ id: "mem-1" });
+    await expect(requireProjectMembership("user-1", "proj-1")).resolves.toBe(true);
+  });
+
+  it("returns false when the user is not a member", async () => {
+    mockUserProjectFindFirst.mockResolvedValue(null);
+    await expect(requireProjectMembership("user-1", "proj-other")).resolves.toBe(false);
+  });
+
+  it("scopes by user and project", async () => {
+    mockUserProjectFindFirst.mockResolvedValue({ id: "mem-1" });
+    await requireProjectMembership("user-1", "proj-1");
+    expect(mockUserProjectFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ user_id: "user-1", project_id: "proj-1" }),
+      }),
+    );
+  });
+
+  it("filters by role only when roles are supplied", async () => {
+    mockUserProjectFindFirst.mockResolvedValue({ id: "mem-1" });
+
+    await requireProjectMembership("user-1", "proj-1");
+    expect(mockUserProjectFindFirst.mock.calls[0]?.[0].where.role).toBeUndefined();
+
+    await requireProjectMembership("user-1", "proj-1", ["OWNER", "EDITOR"]);
+    expect(mockUserProjectFindFirst.mock.calls[1]?.[0].where.role).toEqual({
+      in: ["OWNER", "EDITOR"],
+    });
+  });
+});

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -11,6 +11,7 @@ vi.mock("@/lib/db", () => ({
 
 const {
   forbidden,
+  paginated,
   json,
   jsonError,
   notFoundError,
@@ -167,5 +168,27 @@ describe("requireProjectMembership", () => {
     expect(mockUserProjectFindFirst.mock.calls[1]?.[0].where.role).toEqual({
       in: ["OWNER", "EDITOR"],
     });
+  });
+});
+
+describe("paginated", () => {
+  it("wraps rows in the single list envelope", () => {
+    const body = paginated([{ id: "1" }], { page: 1, pageSize: 25, total: 1 });
+    expect(body).toEqual({
+      data: [{ id: "1" }],
+      pagination: { page: 1, pageSize: 25, total: 1, totalPages: 1 },
+    });
+  });
+
+  it("rounds totalPages up for a partial final page", () => {
+    expect(paginated([], { page: 1, pageSize: 25, total: 51 }).pagination.totalPages).toBe(3);
+  });
+
+  it("reports zero pages for an empty result set", () => {
+    expect(paginated([], { page: 1, pageSize: 25, total: 0 }).pagination.totalPages).toBe(0);
+  });
+
+  it("is exact when total divides evenly by pageSize", () => {
+    expect(paginated([], { page: 2, pageSize: 20, total: 40 }).pagination.totalPages).toBe(2);
   });
 });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -27,6 +27,46 @@ export function json<T>(
   });
 }
 
+/** Pagination block shared by every list endpoint. */
+export interface Pagination {
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+}
+
+/** The single list envelope: `{ data, pagination }`. */
+export interface PaginatedBody<T> {
+  data: T[];
+  pagination: Pagination;
+}
+
+/**
+ * Builds the one list envelope (audit A-H2).
+ *
+ * Three endpoints returned `{ data, pagination: {…} }` while relations and
+ * activity returned a flat `{ data, total, page, pageSize }`. Clients coped
+ * with defensive `Array.isArray(data) ? … : data.data` branches, which is a
+ * sign the contract — not the client — was wrong.
+ *
+ * Standardising matters before Epic 5.1: the export format would otherwise
+ * freeze both shapes permanently.
+ */
+export function paginated<T>(
+  data: T[],
+  init: { page: number; pageSize: number; total: number },
+): PaginatedBody<T> {
+  return {
+    data,
+    pagination: {
+      page: init.page,
+      pageSize: init.pageSize,
+      total: init.total,
+      totalPages: Math.ceil(init.total / init.pageSize),
+    },
+  };
+}
+
 /**
  * Machine-readable error codes (audit A-H4 / X-H-d).
  *

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -28,20 +28,80 @@ export function json<T>(
 }
 
 /**
- * Error response in the shape every route already emits: `{ error, ...extra }`.
- * `extra` carries the per-case fields (`count`, `details`, `filter_url`, …).
+ * Machine-readable error codes (audit A-H4 / X-H-d).
+ *
+ * The `error` field previously carried three incompatible conventions at once —
+ * prose ("Entity not found"), SCREAMING codes ("ENTITY_NOT_FOUND"), and i18n
+ * keys ("auth.errors.tokenExpired") — and the same condition got different
+ * codes in different families (`IN_USE` vs `TYPE_IN_USE`). Clients had no
+ * reliable way to branch on a failure, so they either string-matched or gave up
+ * and showed the raw value to the user.
+ *
+ * Codes are stable API surface: rename one and you break clients. Human copy
+ * belongs in `messages/*.json`, keyed off the code — never in the response.
  */
-export function jsonError(
-  status: number,
-  error: string,
-  extra?: Record<string, unknown>,
-): NextResponse {
-  return json({ error, ...extra }, { status });
+export const ERROR_CODES = [
+  // auth / access
+  "UNAUTHORIZED",
+  "FORBIDDEN",
+  "NO_PROJECT",
+  "RATE_LIMITED",
+  "SERVICE_UNAVAILABLE",
+  // request shape
+  "INVALID_JSON",
+  "VALIDATION_FAILED",
+  "INVALID_QUERY_PARAMS",
+  // resource
+  "NOT_FOUND",
+  "ENTITY_NOT_FOUND",
+  // conflicts
+  "IN_USE",
+  "IN_USE_BY_DELETED",
+  "DUPLICATE_NAME",
+  "DUPLICATE_EVIDENCE",
+  "HAS_SUB_EVENTS",
+  // references / domain rules
+  "INVALID_REFERENCE",
+  "INVALID_FROM_TYPE",
+  "INVALID_TO_TYPE",
+  "INVALID_PROPERTY",
+  "INVALID_ENTITY_TYPE",
+  "DEPTH_LIMIT_EXCEEDED",
+  // auth flows
+  "TOKEN_EXPIRED",
+  "TOKEN_INVALID",
+  "EMAIL_TAKEN",
+] as const;
+
+export type ErrorCode = (typeof ERROR_CODES)[number];
+
+/** The single error envelope every route emits. */
+export interface ApiErrorBody {
+  error: {
+    code: ErrorCode;
+    /** Developer-facing detail. Never rendered to users — clients key off `code`. */
+    message?: string;
+    /** Structured payload: Zod `flatten()`, conflict counts, filter URLs, … */
+    details?: unknown;
+  };
 }
 
-export const unauthorized = (): NextResponse => jsonError(401, "Unauthorized");
-export const forbidden = (): NextResponse => jsonError(403, "Forbidden");
-export const notFoundError = (error = "Not found"): NextResponse => jsonError(404, error);
+/** Error response in the unified `{ error: { code, message?, details? } }` envelope. */
+export function jsonError(
+  status: number,
+  code: ErrorCode,
+  init?: { message?: string; details?: unknown },
+): NextResponse {
+  const error: ApiErrorBody["error"] = { code };
+  if (init?.message !== undefined) error.message = init.message;
+  if (init?.details !== undefined) error.details = init.details;
+  return json({ error }, { status });
+}
+
+export const unauthorized = (): NextResponse => jsonError(401, "UNAUTHORIZED");
+export const forbidden = (): NextResponse => jsonError(403, "FORBIDDEN");
+export const notFoundError = (code: ErrorCode = "NOT_FOUND", message?: string): NextResponse =>
+  jsonError(404, code, message === undefined ? undefined : { message });
 
 /**
  * Reads and JSON-parses a request body.
@@ -55,13 +115,13 @@ export async function parseJsonBody(
   try {
     return { ok: true, data: (await request.json()) as unknown };
   } catch {
-    return { ok: false, response: jsonError(400, "Invalid JSON") };
+    return { ok: false, response: jsonError(400, "INVALID_JSON") };
   }
 }
 
 /**
  * Validates `body` against `schema`, emitting the standard 400 payload
- * (`{ error: "Validation failed", details: flatten() }`) on failure.
+ * (`{ error: { code: "VALIDATION_FAILED", details: flatten() } }`) on failure.
  */
 export function validateBody<S extends z.ZodTypeAny>(
   schema: S,
@@ -71,7 +131,7 @@ export function validateBody<S extends z.ZodTypeAny>(
   if (!parsed.success) {
     return {
       ok: false,
-      response: jsonError(400, "Validation failed", { details: parsed.error.flatten() }),
+      response: jsonError(400, "VALIDATION_FAILED", { details: parsed.error.flatten() }),
     };
   }
   return { ok: true, data: parsed.data as z.infer<S> };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,104 @@
+import type { ProjectRole } from "@prisma/client";
+import { NextResponse } from "next/server";
+import type { z } from "zod";
+
+import { prisma } from "./db";
+
+/**
+ * Shared helpers for API route handlers.
+ *
+ * Every data route repeated the same five blocks: the 401 guard, the
+ * `Cache-Control: no-store` literal, the `Invalid JSON` try/catch, the Zod
+ * validation payload, and the project-membership check (audit X-H-a). Centralising
+ * them keeps the wire format identical while removing ~300 duplicated lines and
+ * giving one place to evolve the error contract (audit A-H4).
+ */
+
+const NO_STORE = { "Cache-Control": "no-store" };
+
+/** JSON response that is never cached. Use instead of `NextResponse.json`. */
+export function json<T>(
+  data: T,
+  init?: { status?: number; headers?: Record<string, string> },
+): NextResponse {
+  return NextResponse.json(data, {
+    status: init?.status ?? 200,
+    headers: { ...NO_STORE, ...init?.headers },
+  });
+}
+
+/**
+ * Error response in the shape every route already emits: `{ error, ...extra }`.
+ * `extra` carries the per-case fields (`count`, `details`, `filter_url`, …).
+ */
+export function jsonError(
+  status: number,
+  error: string,
+  extra?: Record<string, unknown>,
+): NextResponse {
+  return json({ error, ...extra }, { status });
+}
+
+export const unauthorized = (): NextResponse => jsonError(401, "Unauthorized");
+export const forbidden = (): NextResponse => jsonError(403, "Forbidden");
+export const notFoundError = (error = "Not found"): NextResponse => jsonError(404, error);
+
+/**
+ * Reads and JSON-parses a request body.
+ *
+ * Returns a discriminated union rather than throwing so callers keep a flat
+ * control flow: `if (!parsed.ok) return parsed.response;`
+ */
+export async function parseJsonBody(
+  request: Request,
+): Promise<{ ok: true; data: unknown } | { ok: false; response: NextResponse }> {
+  try {
+    return { ok: true, data: (await request.json()) as unknown };
+  } catch {
+    return { ok: false, response: jsonError(400, "Invalid JSON") };
+  }
+}
+
+/**
+ * Validates `body` against `schema`, emitting the standard 400 payload
+ * (`{ error: "Validation failed", details: flatten() }`) on failure.
+ */
+export function validateBody<S extends z.ZodTypeAny>(
+  schema: S,
+  body: unknown,
+): { ok: true; data: z.infer<S> } | { ok: false; response: NextResponse } {
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      response: jsonError(400, "Validation failed", { details: parsed.error.flatten() }),
+    };
+  }
+  return { ok: true, data: parsed.data as z.infer<S> };
+}
+
+/**
+ * True when `userId` belongs to `projectId`.
+ *
+ * `roles` narrows to write-capable membership. Omitting it checks read access.
+ * Call this before any cache lookup — serving a cached response ahead of the
+ * check is exactly how the C1 IDOR leaked cross-tenant data.
+ */
+export async function requireProjectMembership(
+  userId: string,
+  projectId: string,
+  roles?: ProjectRole[],
+): Promise<boolean> {
+  const membership = await prisma.userProject.findFirst({
+    where: {
+      user_id: userId,
+      project_id: projectId,
+      ...(roles ? { role: { in: roles } } : {}),
+    },
+    select: { id: true },
+  });
+  return membership !== null;
+}
+
+/** Roles allowed to mutate project data. */
+export const WRITE_ROLES: ProjectRole[] = ["OWNER", "EDITOR"];

--- a/src/lib/rate-limit.test.ts
+++ b/src/lib/rate-limit.test.ts
@@ -95,9 +95,11 @@ describe("checkRateLimit", () => {
     const response = await checkRateLimit("register:ip", 10, 3_600_000);
     expect(response).not.toBeNull();
     expect(response!.status).toBe(429);
-    const body = (await response!.json()) as { error: string; retryAfter: number };
-    expect(body.error).toBe("auth.errors.rateLimited");
-    expect(typeof body.retryAfter).toBe("number");
+    const body = (await response!.json()) as {
+      error: { code: string; details: { retryAfter: number } };
+    };
+    expect(body.error.code).toBe("RATE_LIMITED");
+    expect(typeof body.error.details.retryAfter).toBe("number");
   });
 
   it("returns 503 (not 429) when the limiter itself is unavailable", async () => {
@@ -105,8 +107,8 @@ describe("checkRateLimit", () => {
     const response = await checkRateLimit("register:ip", 10, 3_600_000);
     expect(response).not.toBeNull();
     expect(response!.status).toBe(503);
-    const body = (await response!.json()) as { error: string };
-    expect(body.error).toBe("auth.errors.serviceUnavailable");
+    const body = (await response!.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
     expect(response!.headers.get("Retry-After")).toBeTruthy();
   });
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -81,7 +81,7 @@ export async function checkRateLimit(
     // caller's fault, so report 503 rather than a misleading "too many requests".
     if (result.degraded) {
       return NextResponse.json(
-        { error: "auth.errors.serviceUnavailable", retryAfter },
+        { error: { code: "SERVICE_UNAVAILABLE", details: { retryAfter } } },
         {
           status: 503,
           headers: { "Retry-After": String(retryAfter), "Cache-Control": "no-store" },
@@ -89,13 +89,14 @@ export async function checkRateLimit(
       );
     }
     return NextResponse.json(
-      { error: "auth.errors.rateLimited", retryAfter },
+      { error: { code: "RATE_LIMITED", details: { retryAfter } } },
       {
         status: 429,
         headers: {
           "Retry-After": String(retryAfter),
           "X-RateLimit-Remaining": "0",
           "X-RateLimit-Reset": result.resetAt.toISOString(),
+          "Cache-Control": "no-store",
         },
       },
     );

--- a/src/lib/schemas/bulk.test.ts
+++ b/src/lib/schemas/bulk.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { bulkDeleteSchema } from "@/lib/schemas/bulk";
+
+const valid = { action: "delete", ids: ["a"], project_id: "proj-1" };
+
+describe("bulkDeleteSchema", () => {
+  it("accepts the unified body", () => {
+    expect(bulkDeleteSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("requires action — sources previously omitted it, so a malformed request deleted", () => {
+    expect(bulkDeleteSchema.safeParse({ ids: ["a"], project_id: "proj-1" }).success).toBe(false);
+  });
+
+  it("rejects any action other than delete", () => {
+    expect(bulkDeleteSchema.safeParse({ ...valid, action: "restore" }).success).toBe(false);
+  });
+
+  it("requires project_id, so a request can never span projects", () => {
+    expect(bulkDeleteSchema.safeParse({ action: "delete", ids: ["a"] }).success).toBe(false);
+  });
+
+  it("rejects the old camelCase projectId spelling", () => {
+    expect(
+      bulkDeleteSchema.safeParse({ action: "delete", ids: ["a"], projectId: "proj-1" }).success,
+    ).toBe(false);
+  });
+
+  it("rejects an empty ids array", () => {
+    expect(bulkDeleteSchema.safeParse({ ...valid, ids: [] }).success).toBe(false);
+  });
+
+  it("rejects empty-string ids", () => {
+    expect(bulkDeleteSchema.safeParse({ ...valid, ids: [""] }).success).toBe(false);
+  });
+
+  it("caps ids at 500 for every family — sources used to cap at 100", () => {
+    const make = (n: number) => ({ ...valid, ids: Array.from({ length: n }, (_, i) => `id-${i}`) });
+    expect(bulkDeleteSchema.safeParse(make(500)).success).toBe(true);
+    expect(bulkDeleteSchema.safeParse(make(501)).success).toBe(false);
+    // 101 used to be rejected by sources alone; it is now uniformly accepted.
+    expect(bulkDeleteSchema.safeParse(make(101)).success).toBe(true);
+  });
+});

--- a/src/lib/schemas/bulk.ts
+++ b/src/lib/schemas/bulk.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+/**
+ * The one bulk-delete contract (audit A-H3).
+ *
+ * The four families had drifted into four contracts: two body casings
+ * (`projectId` vs `project_id`), two scoping models (project taken from the
+ * body vs inferred from the rows themselves), two response shapes (`{deleted}`
+ * vs `{deleted, skipped}`), and two limits (500 vs 100). Sources didn't even
+ * require `action`, so a malformed request could delete rather than 400.
+ *
+ * Taking `project_id` from the body — rather than inferring it from the rows —
+ * is also the safer scoping model: membership is checked against the caller's
+ * stated project, and the delete is then constrained to it, so a request can
+ * never span projects.
+ */
+export const bulkDeleteSchema = z.object({
+  action: z.literal("delete"),
+  ids: z.array(z.string().min(1)).min(1).max(500),
+  project_id: z.string().min(1),
+});
+
+export type BulkDeleteInput = z.infer<typeof bulkDeleteSchema>;
+
+/** Why a requested id was not deleted. */
+export interface BulkSkipped {
+  id: string;
+  reason: string;
+}
+
+/**
+ * Uniform bulk response. `skipped` is always present — an empty array rather
+ * than an omitted field — so clients never branch on its existence.
+ */
+export interface BulkDeleteResult {
+  deleted: number;
+  skipped: BulkSkipped[];
+}

--- a/src/lib/schemas/person.test.ts
+++ b/src/lib/schemas/person.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPersonFormSchema,
+  createPersonSchema,
+  updatePersonSchema,
+} from "@/lib/schemas/person";
+
+const validCreate = { project_id: "proj-1", first_name: "Ada", last_name: "Lovelace" };
+
+function messagesFor(result: { success: boolean; error?: { issues: { message: string }[] } }) {
+  return result.error?.issues.map((i) => i.message) ?? [];
+}
+
+describe("createPersonSchema", () => {
+  it("accepts a minimal valid person", () => {
+    expect(createPersonSchema.safeParse(validCreate).success).toBe(true);
+  });
+
+  it("requires project_id", () => {
+    expect(createPersonSchema.safeParse({ first_name: "Ada", last_name: "Lovelace" }).success).toBe(
+      false,
+    );
+  });
+
+  it("requires at least one name field", () => {
+    const result = createPersonSchema.safeParse({ project_id: "proj-1" });
+    expect(result.success).toBe(false);
+    expect(messagesFor(result)).toContain("name_required");
+  });
+
+  it("accepts a person identified only by a name variant", () => {
+    const result = createPersonSchema.safeParse({
+      project_id: "proj-1",
+      names: [{ name: "Ada" }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a month without a year", () => {
+    const result = createPersonSchema.safeParse({ ...validCreate, birth_month: 3 });
+    expect(result.success).toBe(false);
+    expect(messagesFor(result)).toContain("month_requires_year");
+  });
+
+  it("rejects a day without a month", () => {
+    const result = createPersonSchema.safeParse({
+      ...validCreate,
+      birth_year: 1815,
+      birth_day: 10,
+    });
+    expect(result.success).toBe(false);
+    expect(messagesFor(result)).toContain("day_requires_month");
+  });
+
+  it("applies the same date rules to death fields", () => {
+    const result = createPersonSchema.safeParse({ ...validCreate, death_month: 11 });
+    expect(messagesFor(result)).toContain("month_requires_year");
+  });
+
+  it("rejects out-of-range months and days", () => {
+    expect(
+      createPersonSchema.safeParse({ ...validCreate, birth_year: 1815, birth_month: 13 }).success,
+    ).toBe(false);
+    expect(
+      createPersonSchema.safeParse({
+        ...validCreate,
+        birth_year: 1815,
+        birth_month: 1,
+        birth_day: 32,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("updatePersonSchema", () => {
+  it("allows an empty patch", () => {
+    expect(updatePersonSchema.safeParse({}).success).toBe(true);
+  });
+
+  it("does not require a name (unlike create)", () => {
+    expect(updatePersonSchema.safeParse({ notes: "a note" }).success).toBe(true);
+  });
+
+  it("accepts null to clear a field", () => {
+    expect(updatePersonSchema.safeParse({ birth_year: null, notes: null }).success).toBe(true);
+  });
+
+  it("still enforces the partial-date rules", () => {
+    const result = updatePersonSchema.safeParse({ birth_month: 3 });
+    expect(result.success).toBe(false);
+    expect(messagesFor(result)).toContain("month_requires_year");
+  });
+});
+
+describe("buildPersonFormSchema", () => {
+  it("routes messages through the supplied translator", () => {
+    const schema = buildPersonFormSchema((key) => `translated:${key}`);
+    const result = schema.safeParse({
+      birth_date_certainty: "UNKNOWN",
+      death_date_certainty: "UNKNOWN",
+      birth_month: 3,
+    });
+    expect(result.success).toBe(false);
+    expect(messagesFor(result)).toContain("translated:month_requires_year");
+    expect(messagesFor(result)).toContain("translated:name_required");
+  });
+
+  it("enforces the same rules the server does — the X-H-c drift the form used to have", () => {
+    const schema = buildPersonFormSchema();
+    const withMonthOnly = {
+      first_name: "Ada",
+      birth_date_certainty: "UNKNOWN" as const,
+      death_date_certainty: "UNKNOWN" as const,
+      birth_month: 3,
+    };
+    expect(schema.safeParse(withMonthOnly).success).toBe(false);
+    expect(createPersonSchema.safeParse({ project_id: "p", ...withMonthOnly }).success).toBe(false);
+  });
+
+  it("requires the certainty selectors the form always supplies", () => {
+    const schema = buildPersonFormSchema();
+    expect(schema.safeParse({ first_name: "Ada" }).success).toBe(false);
+  });
+});

--- a/src/lib/schemas/person.ts
+++ b/src/lib/schemas/person.ts
@@ -1,0 +1,157 @@
+import { z } from "zod";
+
+/**
+ * Single source of truth for person validation (audit X-H-b / X-H-c).
+ *
+ * The person schema previously existed three times — in the create route, the
+ * update route, and PersonForm — and had already drifted: the form carried no
+ * `superRefine` at all, so partial-date mistakes skipped client validation and
+ * surfaced as a raw 400 from the server.
+ *
+ * The three shapes genuinely differ (create requires `project_id` and a name;
+ * update accepts `null` to clear a field), so they are composed from shared
+ * field definitions rather than forced into one schema.
+ */
+
+/** Certainty enum — was repeated as a literal 17x across 11 files. */
+export const certaintySchema = z.enum(["CERTAIN", "PROBABLE", "POSSIBLE", "UNKNOWN"]);
+
+export const yearSchema = z.number().int().min(1).max(2100);
+export const monthSchema = z.number().int().min(1).max(12);
+export const daySchema = z.number().int().min(1).max(31);
+
+export const personNameSchema = z.object({
+  name: z.string().min(1),
+  language: z.string().nullable().optional(),
+  is_primary: z.boolean().optional(),
+});
+
+interface PartialDateFields {
+  birth_year?: number | null | undefined;
+  birth_month?: number | null | undefined;
+  birth_day?: number | null | undefined;
+  death_year?: number | null | undefined;
+  death_month?: number | null | undefined;
+  death_day?: number | null | undefined;
+}
+
+/**
+ * Partial-date ordering rules: a month needs a year, a day needs a month.
+ *
+ * `t` lets the client render translated copy while the API keeps emitting the
+ * stable message keys that are part of its contract.
+ */
+export function addPartialDateIssues(
+  data: PartialDateFields,
+  ctx: z.RefinementCtx,
+  t: (key: string) => string = (key) => key,
+): void {
+  const pairs = [
+    ["birth_month", "birth_year", "month_requires_year"],
+    ["birth_day", "birth_month", "day_requires_month"],
+    ["death_month", "death_year", "month_requires_year"],
+    ["death_day", "death_month", "day_requires_month"],
+  ] as const;
+
+  for (const [field, requires, message] of pairs) {
+    if (data[field] && !data[requires]) {
+      ctx.addIssue({ code: "custom", path: [field], message: t(message) });
+    }
+  }
+}
+
+/** A person must be identifiable by at least one of the name fields. */
+export function addNameRequiredIssue(
+  data: {
+    first_name?: string | null | undefined;
+    last_name?: string | null | undefined;
+    names?: unknown[] | undefined;
+  },
+  ctx: z.RefinementCtx,
+  t: (key: string) => string = (key) => key,
+): void {
+  const hasName =
+    (data.first_name && data.first_name.trim().length > 0) ||
+    (data.last_name && data.last_name.trim().length > 0) ||
+    (data.names && data.names.length > 0);
+  if (!hasName) {
+    ctx.addIssue({ code: "custom", path: ["first_name"], message: t("name_required") });
+  }
+}
+
+/** POST /api/persons — `project_id` required, fields absent rather than null. */
+export const createPersonSchema = z
+  .object({
+    project_id: z.string().min(1),
+    first_name: z.string().optional(),
+    last_name: z.string().optional(),
+    birth_year: yearSchema.optional(),
+    birth_month: monthSchema.optional(),
+    birth_day: daySchema.optional(),
+    birth_date_certainty: certaintySchema.optional(),
+    birth_place: z.string().optional(),
+    death_year: yearSchema.optional(),
+    death_month: monthSchema.optional(),
+    death_day: daySchema.optional(),
+    death_date_certainty: certaintySchema.optional(),
+    death_place: z.string().optional(),
+    notes: z.string().optional(),
+    names: z.array(personNameSchema).optional(),
+  })
+  .superRefine((data, ctx) => {
+    addNameRequiredIssue(data, ctx);
+    addPartialDateIssues(data, ctx);
+  });
+
+/** PUT /api/persons/[id] — all fields optional, `null` clears a value. */
+export const updatePersonSchema = z
+  .object({
+    first_name: z.string().optional(),
+    last_name: z.string().optional(),
+    birth_year: yearSchema.optional().nullable(),
+    birth_month: monthSchema.optional().nullable(),
+    birth_day: daySchema.optional().nullable(),
+    birth_date_certainty: certaintySchema.optional(),
+    birth_place: z.string().optional().nullable(),
+    death_year: yearSchema.optional().nullable(),
+    death_month: monthSchema.optional().nullable(),
+    death_day: daySchema.optional().nullable(),
+    death_date_certainty: certaintySchema.optional(),
+    death_place: z.string().optional().nullable(),
+    notes: z.string().optional().nullable(),
+    names: z.array(personNameSchema).optional(),
+  })
+  .superRefine(addPartialDateIssues);
+
+/**
+ * PersonForm — mirrors the update shape but requires the certainty selectors
+ * (the form always has a value) and validates the same rules as the server, so
+ * users no longer discover partial-date mistakes via a raw 400.
+ */
+export function buildPersonFormSchema(t: (key: string) => string = (key) => key) {
+  return z
+    .object({
+      first_name: z.string().optional(),
+      last_name: z.string().optional(),
+      birth_year: yearSchema.optional().nullable(),
+      birth_month: monthSchema.optional().nullable(),
+      birth_day: daySchema.optional().nullable(),
+      birth_date_certainty: certaintySchema,
+      birth_place: z.string().optional(),
+      death_year: yearSchema.optional().nullable(),
+      death_month: monthSchema.optional().nullable(),
+      death_day: daySchema.optional().nullable(),
+      death_date_certainty: certaintySchema,
+      death_place: z.string().optional(),
+      notes: z.string().optional(),
+      names: z.array(personNameSchema).optional(),
+    })
+    .superRefine((data, ctx) => {
+      addNameRequiredIssue(data, ctx, t);
+      addPartialDateIssues(data, ctx, t);
+    });
+}
+
+export type CreatePersonInput = z.infer<typeof createPersonSchema>;
+export type UpdatePersonInput = z.infer<typeof updatePersonSchema>;
+export type PersonFormValues = z.infer<ReturnType<typeof buildPersonFormSchema>>;


### PR DESCRIPTION
Completes the audit's **P2 block** — the changes it flagged as needing to land *before* Epic 2.5's brand work and *before* Epic 5.1 freezes the export contract. Eight commits, each self-contained and independently reviewable.

Builds on #16 (already merged and live).

## What changed

| Finding | Change |
|---|---|
| **X-H-a** | `src/lib/api.ts` — one place for the 401 guard, `no-store`, JSON parsing, Zod payloads and the membership check. 20 routes migrated, **−551 lines** |
| **X-H-b/c** | `src/lib/schemas/person.ts` — the person schema existed 3× (create route, update route, form) and had drifted |
| **A-H4 / X-H-d** | One error envelope: `{ error: { code, message?, details? } }`, plus `api-error.ts` for clients |
| **A-H2** | One list envelope: `{ data, pagination }` |
| **A-H3 + A-M6** | One bulk contract; events bulk N+1 → a single `groupBy` + `updateMany` |
| **F-H4 / F-H5** | i18n sweep: relations area, shared pagination, page titles, aria-labels |
| **F-M9** | `Textarea` / `Select` primitives — 10 call sites, 6 divergent class strings |
| **F-M2 / X-M4** | `useListUrlState` — **−72 lines**, all three `exhaustive-deps` suppressions removed |

Net: **91 files, +2128 / −1856**.

## Breaking API changes (intentional)

Two response shapes changed. Every consumer in this repo is updated in the same commit, and the route tests that asserted the old shapes were migrated rather than loosened — they *are* the contract check.

```diff
- { "error": "Validation failed", "details": {...} }
+ { "error": { "code": "VALIDATION_FAILED", "details": {...} } }

- { "data": [...], "total": 12, "page": 1, "pageSize": 20 }
+ { "data": [...], "pagination": { "page": 1, "pageSize": 20, "total": 12, "totalPages": 1 } }
```

The audit's example was literally true in the code: both `"Entity not found"` and `"ENTITY_NOT_FOUND"` existed, as did `IN_USE` beside `TYPE_IN_USE`. Auth routes also stopped leaking i18n keys (`auth.errors.tokenExpired`) as machine codes.

The bulk contract is also breaking — sources previously did not require `action`, so a malformed request deleted instead of returning 400.

## Bugs found while refactoring

Not in scope, but real, and fixed where the refactor already touched the code:

- **`ActivityLog` read a `hasMore` field the API has never returned.** Its fallback guessed from page length, so a last page that was exactly full offered a "load more" that returned nothing.
- **`ActivityLog` sent `limit=` where the route reads `pageSize`.** Silently ignored — it only worked because `PAGE_SIZE` happened to equal the schema default.
- **`projectId` was declared in the events/persons list-client props and passed by both pages, but never destructured** — so it was silently unavailable in the component.
- **Five `toast.error(data.error ?? …)` call sites** would have rendered `[object Object]` under the new envelope, and previously showed users raw backend codes. Two also hardcoded German.

## Judgement calls

- **`Select` stays a native `<select>`.** Every existing usage is native; a Radix listbox changes keyboard and screen-reader behaviour, which is an Epic 2.5 design decision rather than a refactor side effect.
- **A-M1 (PUT → PATCH) deliberately not done.** It is a contract change that belongs with the Epic 5.1 export work, not bundled here.
- **`useListUrlState` deletes the `exhaustive-deps` suppressions rather than relocating them.** The callbacks closed over `searchParams` inconsistently; the hook depends on `searchParams.toString()` — a value, not an identity — so the deps are now honest.

## Verification

lint, typecheck and build clean. **315 unit tests** pass, up from 253 — the new ones cover `api.ts`, the person schemas, the bulk contract, the pagination helper, both UI primitives, and the URL-state hook (including the asc/desc toggle, which had been copy-pasted three times with no coverage).

E2E is the real gate here, since this touches every route and most forms.

## Not included

- The coverage gate, the last remaining P2 line item — it needs a threshold decision and will likely fail on first run.
- `README.md`, which is uncommitted on this branch by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
