### PR TITLE
Stop E2E from clearing production rate-limit buckets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,14 @@ jobs:
       # project id — without this, a previous run's cached list response could be
       # served against a database that never held those rows. See src/lib/cache.ts.
       CACHE_NAMESPACE: ci-${{ github.run_id }}-${{ github.run_attempt }}
+      # Same reasoning for rate-limit buckets, but this one is a security fix
+      # rather than a correctness one: resetRateLimits() runs in every beforeEach
+      # and deletes under this prefix. Unnamespaced it matched the bare
+      # `@upstash/ratelimit:*`, i.e. production's own brute-force counters on the
+      # shared Upstash instance. src/lib/rate-limit-key.ts refuses to build a
+      # purge target when this is unset, so dropping it fails the run rather than
+      # silently widening the blast radius again.
+      RATELIMIT_NAMESPACE: ci-${{ github.run_id }}-${{ github.run_attempt }}
       AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
       AUTH_URL: "http://localhost:3000"
       NEXT_PUBLIC_APP_URL: "http://localhost:3000"

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -3,6 +3,10 @@ import { createHash, randomBytes } from "crypto";
 import bcrypt from "bcryptjs";
 import { Client } from "pg";
 
+// Relative, not the "@/" alias: Playwright transpiles this file outside the
+// Next build, so tsconfig path mapping is not guaranteed to apply here.
+import { purgeablePrefix } from "../../src/lib/rate-limit-key";
+
 function getClient(): Client {
   const connectionString = process.env.DATABASE_URL_UNPOOLED ?? process.env.DATABASE_URL ?? "";
   return new Client({ connectionString });
@@ -117,9 +121,7 @@ export async function insertTestResetToken(email: string): Promise<string> {
 }
 
 /**
- * Clears all Upstash rate-limit counters for auth endpoints.
- * Uses a single SCAN pass for all keys created by our rate limiters
- * (@upstash/ratelimit prefix), regardless of which AUTH_SECRET created them.
+ * Clears this run's Upstash rate-limit counters for auth endpoints.
  *
  * Credentials resolve the same way the app does (src/lib/env.ts): the Vercel
  * integration's KV_REST_API_* pair first, then the legacy UPSTASH_* one.
@@ -128,8 +130,18 @@ export async function insertTestResetToken(email: string): Promise<string> {
  * real failure: the login limiter allows 5 attempts per 15 minutes per IP+email
  * and every spec logs in as the same seeded admin from the same CI IP, so once
  * this stops clearing counters the whole suite dies of "login just times out".
+ *
+ * Scoped by RATELIMIT_NAMESPACE, and refuses to run without one. That pair of
+ * facts is the safety property: KV_REST_API_* is the Vercel integration's
+ * instance — the same Redis production uses — and this function runs in
+ * beforeEach. Matching the bare `@upstash/ratelimit:*` prefix, as it once did,
+ * deleted production's live buckets several hundred times per run, resetting
+ * the brute-force counters that protect login and password reset.
  */
 export async function resetRateLimits(): Promise<void> {
+  // First, so a missing namespace fails before any network call is made.
+  const prefix = purgeablePrefix();
+
   const url = process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
   if (!url || !token) {
@@ -142,12 +154,13 @@ export async function resetRateLimits(): Promise<void> {
 
   const headers = { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
 
-  // Single SCAN pass — clears all sliding-window keys for every auth action/IP.
-  // Keys are stored as: @upstash/ratelimit:{action}:{anonIp}[:{email}]:{windowBucket}
+  // Single SCAN pass — clears this namespace's sliding-window keys for every
+  // auth action/IP. Keys are stored as:
+  //   {prefix}:{action}:{anonIp}[:{email}]:{windowBucket}
   let cursor = "0";
   do {
     const scanUrl = new URL(`${url}/scan/${cursor}`);
-    scanUrl.searchParams.set("match", "@upstash/ratelimit:*");
+    scanUrl.searchParams.set("match", `${prefix}:*`);
     scanUrl.searchParams.set("count", "100");
 
     const scanRes = await fetch(scanUrl, { headers });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,7 +25,10 @@ export default defineConfig({
   retries: process.env["CI"] ? 2 : 0,
   // One worker everywhere. These specs share a single database and a single
   // Redis, so parallel files interfere: every beforeEach calls resetRateLimits(),
-  // which clears *all* buckets and would wipe SEC-05's counter mid-test.
+  // which clears every bucket *in this run's namespace* and would wipe SEC-05's
+  // counter mid-test. RATELIMIT_NAMESPACE does not help here — it isolates runs
+  // from each other and from production, but all workers in a run share one
+  // namespace because they share one server process.
   // CI already ran with 1; matching it locally keeps local reproducible.
   workers: 1,
   reporter: "html",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,6 +10,14 @@ if (existsSync(envLocalPath)) {
   process.loadEnvFile(envLocalPath);
 }
 
+// Namespace every rate-limit key this run touches. Upstash is shared with
+// production even when the database is not, and resetRateLimits() deletes under
+// this prefix on every beforeEach — unnamespaced, that deletes production's
+// brute-force counters. CI sets a per-run value; this default covers local runs
+// so no one has to remember. Both the runner and the server it spawns must
+// agree, hence the explicit hand-off in webServer.env below.
+process.env["RATELIMIT_NAMESPACE"] ??= "local-e2e";
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
@@ -38,7 +46,13 @@ export default defineConfig({
   webServer: {
     command: "pnpm dev",
     port: 3000,
+    // NOTE: with reuseExistingServer, an already-running dev server keeps its
+    // own env. If it was started without RATELIMIT_NAMESPACE it writes buckets
+    // under the bare prefix, resetRateLimits() clears a namespace nothing is
+    // writing to, and the suite dies on rate limits instead. Restart the dev
+    // server if auth specs start timing out.
     reuseExistingServer: true,
     timeout: 120000,
+    env: { RATELIMIT_NAMESPACE: process.env["RATELIMIT_NAMESPACE"] ?? "local-e2e" },
   },
 });

--- a/src/lib/cache.test.ts
+++ b/src/lib/cache.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Hoisted mock for redis module — must be declared before the cache import
 const mockGet = vi.fn();
@@ -118,5 +118,48 @@ describe("cache.invalidateByPrefix", () => {
   it("is silent when redis throws", async () => {
     mockScan.mockRejectedValue(new Error("Redis down"));
     await expect(cache.invalidateByPrefix("any:")).resolves.toBeUndefined();
+  });
+});
+
+describe("cache key namespace", () => {
+  const ORIGINAL = process.env["CACHE_NAMESPACE"];
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env["CACHE_NAMESPACE"];
+    else process.env["CACHE_NAMESPACE"] = ORIGINAL;
+    vi.resetModules();
+  });
+
+  it("leaves keys unchanged when CACHE_NAMESPACE is unset, as in dev and production", async () => {
+    vi.resetAllMocks();
+    delete process.env["CACHE_NAMESPACE"];
+    vi.resetModules();
+    const { cache: unnamespaced } = await import("@/lib/cache");
+    mockGet.mockResolvedValue(null);
+    await unnamespaced.get("person-list:seed-project-demo:1:25");
+    expect(mockGet).toHaveBeenCalledWith("cache:person-list:seed-project-demo:1:25");
+  });
+
+  // Cache keys are built from the seed project id, which is fixed. Two CI runs
+  // less than the 60s TTL apart would otherwise serve run N's cached rows
+  // against run N+1's database — each run now has a fresh Neon branch but they
+  // still share one Upstash instance.
+  it("scopes keys to the namespace when CACHE_NAMESPACE is set", async () => {
+    vi.resetAllMocks();
+    process.env["CACHE_NAMESPACE"] = "ci-42-1";
+    vi.resetModules();
+    const { cache: namespaced } = await import("@/lib/cache");
+    mockGet.mockResolvedValue(null);
+    await namespaced.get("person-list:seed-project-demo:1:25");
+    expect(mockGet).toHaveBeenCalledWith("cache:ci-42-1:person-list:seed-project-demo:1:25");
+  });
+
+  it("applies the namespace to writes as well as reads", async () => {
+    vi.resetAllMocks();
+    process.env["CACHE_NAMESPACE"] = "ci-42-1";
+    vi.resetModules();
+    const { cache: namespaced } = await import("@/lib/cache");
+    await namespaced.set("k", { v: 1 }, 60);
+    expect(mockSet).toHaveBeenCalledWith("cache:ci-42-1:k", { v: 1 }, { ex: 60 });
   });
 });

--- a/src/lib/rate-limit-key.test.ts
+++ b/src/lib/rate-limit-key.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { RATE_LIMIT_BASE_PREFIX, purgeablePrefix, rateLimitPrefix } from "@/lib/rate-limit-key";
+
+const ORIGINAL = process.env["RATELIMIT_NAMESPACE"];
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env["RATELIMIT_NAMESPACE"];
+  else process.env["RATELIMIT_NAMESPACE"] = ORIGINAL;
+});
+
+describe("rateLimitPrefix", () => {
+  it("returns the bare prefix when no namespace is configured", () => {
+    expect(rateLimitPrefix(undefined)).toBe(RATE_LIMIT_BASE_PREFIX);
+  });
+
+  it("appends the namespace as a key segment when one is configured", () => {
+    expect(rateLimitPrefix("ci-42-1")).toBe(`${RATE_LIMIT_BASE_PREFIX}:ci-42-1`);
+  });
+
+  it("treats an empty namespace as unset, rather than producing a trailing colon", () => {
+    expect(rateLimitPrefix("")).toBe(RATE_LIMIT_BASE_PREFIX);
+  });
+
+  it("reads RATELIMIT_NAMESPACE from the environment by default", () => {
+    process.env["RATELIMIT_NAMESPACE"] = "from-env";
+    expect(rateLimitPrefix()).toBe(`${RATE_LIMIT_BASE_PREFIX}:from-env`);
+  });
+});
+
+describe("purgeablePrefix", () => {
+  // The whole point of this function: a test run must never be able to issue a
+  // DEL against keys it does not own. Production's buckets live under the bare
+  // prefix, so refusing to build a purge target without a namespace is what
+  // makes wiping them impossible rather than merely unlikely.
+  it("throws when no namespace is configured, so unnamespaced keys can never be purged", () => {
+    expect(() => purgeablePrefix(undefined)).toThrow(/namespace/i);
+  });
+
+  it("throws on an empty namespace, which would otherwise match every key", () => {
+    expect(() => purgeablePrefix("")).toThrow(/namespace/i);
+  });
+
+  it("returns a prefix scoped to the namespace when one is configured", () => {
+    expect(purgeablePrefix("ci-42-1")).toBe(`${RATE_LIMIT_BASE_PREFIX}:ci-42-1`);
+  });
+
+  it("never returns the bare prefix, which is what production uses", () => {
+    expect(purgeablePrefix("anything")).not.toBe(RATE_LIMIT_BASE_PREFIX);
+  });
+
+  it("reads RATELIMIT_NAMESPACE from the environment by default", () => {
+    process.env["RATELIMIT_NAMESPACE"] = "local-e2e";
+    expect(purgeablePrefix()).toBe(`${RATE_LIMIT_BASE_PREFIX}:local-e2e`);
+  });
+});

--- a/src/lib/rate-limit-key.ts
+++ b/src/lib/rate-limit-key.ts
@@ -1,0 +1,48 @@
+/**
+ * Redis key namespacing for the rate limiter.
+ *
+ * Deliberately dependency-free: the E2E fixture helpers import this too, and
+ * pulling in `./redis` there would construct an Upstash client just to learn a
+ * string. Keeping the prefix in one place is what stops the app and the test
+ * helpers from drifting onto different key spaces.
+ */
+
+/** The prefix `@upstash/ratelimit` uses by default, and what production writes under. */
+export const RATE_LIMIT_BASE_PREFIX = "@upstash/ratelimit";
+
+/**
+ * Prefix the limiter writes under.
+ *
+ * Unset in dev and production, so keys keep their historical shape. CI sets it
+ * per run: every run now gets a fresh Neon branch but still shares one Upstash
+ * instance with production, and rate-limit buckets are keyed by action and
+ * anonymised IP — values that collide across environments.
+ */
+export function rateLimitPrefix(
+  namespace: string | undefined = process.env["RATELIMIT_NAMESPACE"],
+): string {
+  return namespace ? `${RATE_LIMIT_BASE_PREFIX}:${namespace}` : RATE_LIMIT_BASE_PREFIX;
+}
+
+/**
+ * Prefix a test run is allowed to delete under, and the reason this module exists.
+ *
+ * Throws when there is no namespace. The E2E suite resets rate-limit buckets
+ * between tests, and without a namespace the only prefix it could match is the
+ * bare one — i.e. production's own buckets, on the shared Upstash instance.
+ * Failing loudly here makes that impossible by construction rather than relying
+ * on the caller to remember.
+ */
+export function purgeablePrefix(
+  namespace: string | undefined = process.env["RATELIMIT_NAMESPACE"],
+): string {
+  if (!namespace) {
+    throw new Error(
+      "purgeablePrefix: RATELIMIT_NAMESPACE is not set. Refusing to build a purge " +
+        "target that would match unnamespaced rate-limit keys — those belong to " +
+        "production, which shares this Upstash instance. Set RATELIMIT_NAMESPACE " +
+        "to a per-run value before resetting rate limits.",
+    );
+  }
+  return `${RATE_LIMIT_BASE_PREFIX}:${namespace}`;
+}

--- a/src/lib/rate-limit.test.ts
+++ b/src/lib/rate-limit.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Hoisted mock — must be before any import that resolves the rate-limit module
 const mockLimit = vi.fn();
@@ -150,5 +150,41 @@ describe("msToDuration (via limiter call args)", () => {
       typeof vi.fn
     >;
     expect(sw).toHaveBeenCalledWith(5, "15 m");
+  });
+});
+
+describe("rate-limit key namespace", () => {
+  const ORIGINAL = process.env["RATELIMIT_NAMESPACE"];
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (MockRatelimit as unknown as Record<string, unknown>).slidingWindow = vi
+      .fn()
+      .mockReturnValue("window");
+    MockRatelimit.mockImplementation(() => ({ limit: mockLimit }));
+    mockLimit.mockResolvedValue({ success: true, remaining: 1, reset: Date.now() + 1_000 });
+  });
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env["RATELIMIT_NAMESPACE"];
+    else process.env["RATELIMIT_NAMESPACE"] = ORIGINAL;
+  });
+
+  it("writes under the bare prefix when no namespace is configured", async () => {
+    delete process.env["RATELIMIT_NAMESPACE"];
+    await createRedisRateLimiter().check("k", 5, 60_000);
+    expect(MockRatelimit).toHaveBeenCalledWith(
+      expect.objectContaining({ prefix: "@upstash/ratelimit" }),
+    );
+  });
+
+  // Without this, a CI run and production share bucket keys on the one Upstash
+  // instance — which is what let the E2E reset clear production's buckets.
+  it("writes under a namespaced prefix when RATELIMIT_NAMESPACE is set", async () => {
+    process.env["RATELIMIT_NAMESPACE"] = "ci-42-1";
+    await createRedisRateLimiter().check("k", 5, 60_000);
+    expect(MockRatelimit).toHaveBeenCalledWith(
+      expect.objectContaining({ prefix: "@upstash/ratelimit:ci-42-1" }),
+    );
   });
 });

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,6 +1,7 @@
 import { Ratelimit } from "@upstash/ratelimit";
 import type { NextResponse } from "next/server";
 
+import { rateLimitPrefix } from "./rate-limit-key";
 import { redis } from "./redis";
 
 export interface RateLimitResult {
@@ -45,7 +46,7 @@ export function createRedisRateLimiter(): RateLimiter {
         const limiter = new Ratelimit({
           redis,
           limiter: Ratelimit.slidingWindow(limit, msToDuration(windowMs)),
-          prefix: "@upstash/ratelimit",
+          prefix: rateLimitPrefix(),
         });
         const { success, remaining, reset } = await limiter.limit(key);
         return { allowed: success, remaining, resetAt: new Date(reset), degraded: false };


### PR DESCRIPTION
Closes #19. **Stacked on #25** — base is `chore/p3-deps-and-ephemeral-ci`, so review that one first. The diff here is just the one commit.

## The bug

`resetRateLimits()` ran in every `beforeEach` and deleted every key matching `@upstash/ratelimit:*`. `KV_REST_API_*` is the Vercel integration's instance — the same Redis production uses — so each CI run reset production's live brute-force counters several hundred times. Local E2E runs did the same.

Those counters are the defence on login and password reset, and the limiter was deliberately switched to **fail closed** (audit S-M2). Clearing them silently removed the protection rather than degrading it.

Database separation on 2026-08-09 fixed Postgres but not Redis; ephemeral CI branches (#25) give each run a fresh *database*, still on a shared *Upstash instance*.

## Evidence

Checked against the live shared instance before and after:

```
@upstash/ratelimit:*                   matches 1 key(s)   <- the old purge pattern
@upstash/ratelimit:local-e2e:*         matches 0 key(s)
@upstash/ratelimit:ci-42-1:*           matches 0 key(s)
```

That one key was a real unnamespaced login bucket for `admin@evidoxa.dev` — exactly what the old pattern deleted.

## The fix

Rate-limit keys are namespaced by `RATELIMIT_NAMESPACE`, mirroring `CACHE_NAMESPACE`. Unset in dev and production, so their keys keep their historical shape.

`src/lib/rate-limit-key.ts` is new and deliberately **dependency-free** — the E2E helpers import it rather than duplicating the prefix string, and pulling in `./redis` there would construct an Upstash client just to learn a string.

**`purgeablePrefix()` throws when no namespace is set, and that is the actual fix.** Without a namespace the only prefix the purge could match is the bare one — production's. Removing the env var now fails the run loudly instead of silently widening the blast radius again. Drift between the app and the helper is also caught: the reset would clear a namespace nothing writes to, and the suite dies on rate limits rather than passing quietly.

Local runs are covered without anyone having to remember: `playwright.config.ts` defaults to `local-e2e` and hands it to the dev server it spawns. The `reuseExistingServer` caveat is documented inline.

## Also: a test gap in #25

`CACHE_NAMESPACE` shipped with **zero** test coverage. Added three tests — and since they passed immediately against existing code, I verified they are meaningful by mutating `cache.ts` to ignore the namespace and confirming they fail, then restoring it.

## Verification

`lint` 0 · `typecheck` 0 · **1219/1219 tests** (was 1205; +14) · `build` compiled, 20/20 static pages · workflow YAML parses.

TDD throughout: `rate-limit-key.test.ts` was written first and watched fail on the missing module; the limiter-prefix test was watched fail with the bare prefix before wiring it up.

## Not verified here

The E2E suite itself was not run — it needs a database and a server, and #25's CI run is the first real exercise of that path. The behaviour under test is covered by unit tests and by the live Redis scan above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
