### PR TITLE
Refuse to run E2E against the production database

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,9 @@
+## Active platform
+
+UX skill overlay: `skills/platforms/evidoxa.md`. Load it whenever running the UX review/audit
+skills (`ux`, `ux-audit`, `ux-mr`, `ux-reviewer`, etc.) against this repo — it supplies the
+user-type vocabulary, mental-model rules, brand voice, and stack adapter specific to Evidoxa.
+
 ## Context efficiency
 
 Be conservative with tool output.
@@ -80,3 +86,37 @@ against what is now known, and merge duplicates. Report what changed and why.
 
 Prefer splitting an issue that has grown several independent parts — progress on
 one should be visible without waiting for the rest.
+
+## Measure, don't infer
+
+When a claim can be tested, test it before acting on it, writing it into an issue,
+or reporting it as fact.
+
+Three wrong conclusions in one session, each a reasonable inference from real
+evidence, each wrong:
+
+- A `Windows NT 10.0` user-agent in the audit log was read as proof of a Windows
+  machine. It is Playwright's default and appears identically from macOS — the
+  same value was sitting in the dev database from a local run.
+- `vercel env ls` showing "154d ago" was read as "not rotated". That column is
+  **created**, not updated. Acting on it overwrote a production credential.
+- Code reading the leftmost `X-Forwarded-For` was written up as a live,
+  exploitable rate-limit bypass. Vercel overwrites that header; two requests and
+  a hash comparison disproved it in a minute, after the issue was already filed.
+
+What to do instead:
+
+- **Ask the system, not the name.** Branch identity comes from
+  `SELECT current_setting('neon.branch_id')` — never a hostname, env var name, or
+  row count. Endpoint names in this project are actively misleading.
+- **Run the experiment.** Send the two requests and compare. Mutate the
+  implementation and confirm the test fails. Point the guard at the thing it is
+  meant to refuse and watch it refuse.
+- **Check what a field means** before trusting it — created vs. updated, local vs.
+  UTC, default vs. host-derived.
+- For anything security-relevant, destructive, or headed for production,
+  measurement is required rather than preferred.
+
+Say which claims were measured and which were inferred. An inference must never
+reach an issue, a commit message, or a production action wearing the confidence of
+a measurement.

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,41 @@
+import { Client } from "pg";
+
+import { assertNotProductionBranch } from "./helpers/guard";
+
+/**
+ * Refuses to start the suite when it is pointed at the production database.
+ *
+ * This runs once, before any spec, and that placement is the point. The
+ * per-connection guard in `helpers/db.ts` only fires for specs that actually
+ * query Postgres — and `security.spec.ts` does not. It drives the app purely
+ * over HTTP and its only helper is `resetRateLimits()`, which talks to Upstash.
+ * That is precisely the spec that put 20 fixture accounts into the live
+ * database on 2026-08-09, so a guard it can bypass is not a guard.
+ *
+ * Known limitation: this checks the database the *test runner* is configured
+ * for. If someone starts the app server with production credentials but runs
+ * the runner against dev, this will not catch it. In every real setup here
+ * (local, CI) one environment feeds both, so it holds — but it is a check on
+ * configuration, not proof of what the server under test is talking to.
+ */
+export default async function globalSetup(): Promise<void> {
+  const connectionString =
+    process.env["DATABASE_URL_UNPOOLED"] ?? process.env["DATABASE_URL"] ?? "";
+  if (!connectionString) {
+    throw new Error(
+      "E2E database guard: neither DATABASE_URL_UNPOOLED nor DATABASE_URL is set. " +
+        "Refusing to start — the suite cannot verify which database it would write to.",
+    );
+  }
+
+  const client = new Client({ connectionString });
+  await client.connect();
+  try {
+    const res = await client.query<{ branch: string | null }>(
+      "SELECT current_setting('neon.branch_id', true) AS branch",
+    );
+    assertNotProductionBranch(res.rows[0]?.branch);
+  } finally {
+    await client.end();
+  }
+}

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -7,6 +7,34 @@ import { Client } from "pg";
 // Next build, so tsconfig path mapping is not guaranteed to apply here.
 import { purgeablePrefix } from "../../src/lib/rate-limit-key";
 
+import { assertNotProductionBranch } from "./guard";
+
+/**
+ * Every branch identity check the suite needs, done once per process.
+ *
+ * `current_setting(..., true)` returns NULL instead of erroring when the
+ * setting is absent, so a non-Neon connection reaches the guard as "unknown"
+ * and is refused there rather than throwing something opaque here.
+ */
+let branchChecked = false;
+
+async function connectGuarded(client: Client): Promise<void> {
+  await client.connect();
+  if (branchChecked) return;
+  try {
+    const res = await client.query<{ branch: string | null }>(
+      "SELECT current_setting('neon.branch_id', true) AS branch",
+    );
+    assertNotProductionBranch(res.rows[0]?.branch);
+    branchChecked = true;
+  } catch (err) {
+    // Callers connect *before* their try/finally, so without this the socket
+    // stays open when the guard refuses and the runner hangs instead of failing.
+    await client.end().catch(() => {});
+    throw err;
+  }
+}
+
 function getClient(): Client {
   const connectionString = process.env.DATABASE_URL_UNPOOLED ?? process.env.DATABASE_URL ?? "";
   return new Client({ connectionString });
@@ -15,7 +43,7 @@ function getClient(): Client {
 /** Returns the raw token for the most recent email verification for a given email. */
 export async function getLatestVerificationToken(email: string): Promise<string> {
   const client = getClient();
-  await client.connect();
+  await connectGuarded(client);
   try {
     const result = await client.query<{ token_hash: string }>(
       `SELECT ec.token_hash
@@ -43,7 +71,7 @@ export async function getLatestVerificationToken(email: string): Promise<string>
  *  or use the insertTestResetToken helper below. */
 export async function getLatestResetTokenHash(email: string): Promise<string> {
   const client = getClient();
-  await client.connect();
+  await connectGuarded(client);
   try {
     const result = await client.query<{ token_hash: string }>(
       `SELECT pr.token_hash
@@ -67,7 +95,7 @@ export async function insertTestVerificationToken(email: string): Promise<string
   const rawToken = "a".repeat(64); // deterministic test token
   const tokenHash = createHash("sha256").update(rawToken).digest("hex");
   const client = getClient();
-  await client.connect();
+  await connectGuarded(client);
   try {
     // Delete any existing tokens for this user
     await client.query(
@@ -102,7 +130,7 @@ export async function insertTestResetToken(email: string): Promise<string> {
   const rawToken = randomBytes(32).toString("hex");
   const tokenHash = createHash("sha256").update(rawToken).digest("hex");
   const client = getClient();
-  await client.connect();
+  await connectGuarded(client);
   try {
     await client.query(
       `DELETE FROM password_resets
@@ -187,7 +215,7 @@ export async function resetRateLimits(): Promise<void> {
 export async function createTestUser(email: string, password: string): Promise<void> {
   const password_hash = await bcrypt.hash(password, 10);
   const client = getClient();
-  await client.connect();
+  await connectGuarded(client);
   try {
     await client.query("DELETE FROM users WHERE email = $1", [email.toLowerCase()]);
     await client.query(
@@ -203,7 +231,7 @@ export async function createTestUser(email: string, password: string): Promise<v
 /** Deletes a test user by email (for cleanup after registration tests). */
 export async function deleteTestUser(email: string): Promise<void> {
   const client = getClient();
-  await client.connect();
+  await connectGuarded(client);
   try {
     await client.query("DELETE FROM users WHERE email = $1", [email.toLowerCase()]);
   } finally {
@@ -214,7 +242,7 @@ export async function deleteTestUser(email: string): Promise<void> {
 /** Marks a user's email as verified (for login tests). */
 export async function verifyUserEmail(email: string): Promise<void> {
   const client = getClient();
-  await client.connect();
+  await connectGuarded(client);
   try {
     await client.query("UPDATE users SET email_verified_at = NOW() WHERE email = $1", [
       email.toLowerCase(),

--- a/e2e/helpers/guard.ts
+++ b/e2e/helpers/guard.ts
@@ -1,0 +1,52 @@
+/**
+ * Refuses to let the E2E suite touch the production database.
+ *
+ * On 2026-08-09 a machine ran this suite against a localhost server that was
+ * configured with the production `DATABASE_URL`. Twenty fixture accounts were
+ * created in the live database and nothing in the suite objected — the specs
+ * cannot tell one Postgres connection from another, and `.env.local` is enough
+ * to point them anywhere.
+ *
+ * Neon exposes the branch identity *inside the session*, so the check does not
+ * depend on hostnames, environment variable names, or anyone remembering which
+ * is which. Endpoint hostnames in this project are actively misleading and have
+ * caused exactly this class of mistake before, so this is the only form of the
+ * check worth trusting.
+ *
+ * Deliberately dependency-free so `db.ts` can use it without pulling anything
+ * in, and so it is unit-testable (see src/test/e2e-db-guard.test.ts — vitest
+ * excludes **\/e2e\/** from test discovery, but imports across it are fine).
+ */
+
+/** Neon branch backing Vercel production. Not a secret; it is an identifier. */
+export const PRODUCTION_BRANCH_ID = "br-old-grass-a9acitgb";
+
+/**
+ * Throws unless the connected Neon branch is safe to write fixtures into.
+ *
+ * Fails closed on an unknown branch: if we cannot prove which database we are
+ * pointed at, we must not write to it. Every environment in this project is
+ * Neon (dev, ephemeral per-run CI branches, production), so a missing
+ * `neon.branch_id` means the connection is not what anyone intended — not that
+ * some exotic-but-fine setup is in play.
+ */
+export function assertNotProductionBranch(branchId: string | null | undefined): void {
+  if (!branchId) {
+    throw new Error(
+      "E2E database guard: could not determine which database this is — " +
+        "`neon.branch_id` was empty. Refusing to run: the suite creates and " +
+        "deletes rows, and an unidentified connection could be production. " +
+        "Check DATABASE_URL / DATABASE_URL_UNPOOLED point at a Neon branch.",
+    );
+  }
+
+  if (branchId === PRODUCTION_BRANCH_ID) {
+    throw new Error(
+      `E2E database guard: refusing to run against the PRODUCTION branch ` +
+        `(${PRODUCTION_BRANCH_ID}). The suite registers users and deletes rows; ` +
+        `running it here puts fixtures in the live database. Point ` +
+        `DATABASE_URL / DATABASE_URL_UNPOOLED at the dev branch or an ephemeral ` +
+        `CI branch instead.`,
+    );
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,6 +20,10 @@ process.env["RATELIMIT_NAMESPACE"] ??= "local-e2e";
 
 export default defineConfig({
   testDir: "./e2e",
+  // Refuses to start against the production database. Runs before any spec,
+  // because the per-connection guard in helpers/db.ts cannot cover specs that
+  // never touch Postgres — see e2e/global-setup.ts.
+  globalSetup: "./e2e/global-setup.ts",
   fullyParallel: true,
   forbidOnly: !!process.env["CI"],
   retries: process.env["CI"] ? 2 : 0,

--- a/src/test/e2e-db-guard.test.ts
+++ b/src/test/e2e-db-guard.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+// The guard itself lives with the E2E helpers (it is test infrastructure, not
+// app code), but vitest excludes **/e2e/**, so its unit test lives here.
+import { PRODUCTION_BRANCH_ID, assertNotProductionBranch } from "../../e2e/helpers/guard";
+
+describe("assertNotProductionBranch", () => {
+  // On 2026-08-09 a machine ran the E2E suite against a localhost server that
+  // was wired to the production database, creating 20 fixture accounts there.
+  // Nothing in the suite objected. This is the objection.
+  it("throws when connected to the production branch", () => {
+    expect(() => assertNotProductionBranch(PRODUCTION_BRANCH_ID)).toThrow(/production/i);
+  });
+
+  it("names the branch in the error so the message is actionable", () => {
+    expect(() => assertNotProductionBranch(PRODUCTION_BRANCH_ID)).toThrow(
+      new RegExp(PRODUCTION_BRANCH_ID),
+    );
+  });
+
+  it("allows the dev branch", () => {
+    expect(() => assertNotProductionBranch("br-falling-resonance-a9xyd5y9")).not.toThrow();
+  });
+
+  it("allows an ephemeral per-run CI branch", () => {
+    expect(() => assertNotProductionBranch("br-royal-meadow-a9rsw9na")).not.toThrow();
+  });
+
+  // Fails closed, deliberately: if we cannot prove which database we are
+  // pointed at, we must not write fixtures into it. Every environment here is
+  // Neon, so an absent branch id means something is wrong, not something exotic.
+  it("throws when the branch cannot be determined (null)", () => {
+    expect(() => assertNotProductionBranch(null)).toThrow(/could not determine|unknown/i);
+  });
+
+  it("throws when the branch cannot be determined (undefined)", () => {
+    expect(() => assertNotProductionBranch(undefined)).toThrow(/could not determine|unknown/i);
+  });
+
+  it("throws on an empty branch id rather than treating it as safe", () => {
+    expect(() => assertNotProductionBranch("")).toThrow(/could not determine|unknown/i);
+  });
+
+  it("points at the setting to check when the branch is unknown", () => {
+    expect(() => assertNotProductionBranch(null)).toThrow(/neon\.branch_id/);
+  });
+});


### PR DESCRIPTION
Addresses the 2026-08-09 incident: a machine ran the E2E suite against a localhost server configured with the production `DATABASE_URL`, creating 20 fixture accounts in the live database. Nothing in the suite objected.

## The check

Ask the database which branch it is, via Neon's in-session `current_setting('neon.branch_id')` — not a hostname, not an env var name, not a row count. Endpoint hostnames in this project are actively misleading and have already caused this class of mistake once.

`assertNotProductionBranch()` is dependency-free and unit-tested (8 tests). It **fails closed on an unknown branch**: if we cannot prove which database this is, we must not write fixtures into it. Every environment here is Neon, so a missing branch id means the connection is not what anyone intended.

## Why it runs in two places

The per-connection guard in `helpers/db.ts` covers the seven Postgres call sites. That alone would **not** have stopped the incident.

`security.spec.ts` — the spec that caused it — never queries Postgres. It drives the app over HTTP and its only helper is `resetRateLimits()`, which talks to Upstash. So a Playwright `globalSetup` runs the same assertion once, before any spec, regardless of what that spec touches.

## Verified against the real branches

| | result |
|---|---|
| `helpers/db.ts` → production | refused |
| `helpers/db.ts` → dev | allowed through to normal behaviour |
| `globalSetup` → production | refused |
| `globalSetup` → dev | allowed |
| `playwright test e2e/security.spec.ts` → production | **aborts before any request** |

Also fixed a defect found by running it rather than reasoning about it: callers connect *outside* their `try/finally`, so the first version left the socket open when it refused and the runner hung instead of failing. `connectGuarded()` now closes the client before rethrowing.

## Known limitation

Documented in `global-setup.ts`: this checks the database the test **runner** is configured for, not what the server under test is talking to. If someone starts the app with production credentials but runs the runner against dev, it won't catch it. In every real setup here one environment feeds both.

## Also

`CLAUDE.md` gains a **measure, don't infer** convention, written from three wrong conclusions in this session — a user-agent misread as host evidence, a `created` column misread as `updated` (which overwrote a production credential), and a rate-limit bypass reported as live before being disproved by two requests. Measurement is now required, not preferred, for anything security-relevant, destructive, or production-bound.

That commit also carries a pre-existing uncommitted "Active platform" paragraph referencing `skills/platforms/evidoxa.md`, which is still untracked — so that link does not resolve in the repo yet.

## Verification

`lint` 0 · `typecheck` 0 · **1227/1227 tests** (was 1219; +8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
