### PR TITLE
fix(auth): give every user a project, so records can actually be created

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ Every user-data table carries `project_id`, and access runs through `UserProject
 `OWNER` / `EDITOR` / `VIEWER` roles. Retrofitting tenancy is notoriously error-prone; it was
 designed in from the first migration.
 
+Because every write needs a project, one is provisioned on first sign-in and the user is made
+its `OWNER` (`src/lib/project.ts`). The active project is then the user's first `OWNER`/`EDITOR`
+membership, carried in the session — a stopgap until the project switcher replaces it, and the
+reason there is no "no project" state to design around.
+
 ---
 
 ## Relationship to CIDOC CRM

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { writeAuditLog } from "@/lib/audit";
 import { ACCOUNT_LOCKOUT_MINUTES, SIGN_IN_CODES, type SignInCode } from "@/lib/auth-errors";
 import { prisma } from "@/lib/db";
+import { attachProjectId, ensureDefaultProject } from "@/lib/project";
 import { rateLimiter } from "@/lib/rate-limit";
 import { anonymizeIp } from "@/lib/security";
 
@@ -127,22 +128,33 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         await writeAuditLog({ action: "LOGIN_SUCCESS", userId: user.id, request });
 
         // TODO: Epic 3.1 — replace with project switcher
-        const userProject = await prisma.userProject.findFirst({
-          where: {
-            user_id: user.id,
-            role: { in: ["OWNER", "EDITOR"] },
-          },
-          orderBy: { created_at: "asc" },
-        });
+        const projectId = await ensureDefaultProject(user.id);
 
         return {
           id: user.id,
           email: user.email,
           name: user.name,
           role: user.role,
-          ...(userProject?.project_id ? { projectId: userProject.project_id } : {}),
+          ...(projectId ? { projectId } : {}),
         };
       },
     }),
   ],
+  callbacks: {
+    ...authConfig.callbacks,
+    // Sessions minted before default-project provisioning existed carry no
+    // projectId, and the JWT lasts 30 days — without this those users stay
+    // unable to create anything until they happen to sign out (#64).
+    //
+    // This has to be the `session` callback, not `jwt`: measured on 2026-08-12,
+    // `jwt` runs only on sign-in and on `updateAge` rotation, so a backfill
+    // there never executed on an ordinary page request. `session` runs on every
+    // `auth()` call. Node-side config only — `auth.config.ts` must stay
+    // Prisma-free for the Edge middleware.
+    async session(params) {
+      const session = (await authConfig.callbacks?.session?.(params)) ?? params.session;
+      await attachProjectId(session);
+      return session;
+    },
+  },
 });

--- a/src/lib/project.test.ts
+++ b/src/lib/project.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUserProjectFindFirst = vi.fn();
+const mockProjectCreate = vi.fn();
+const mockUserProjectCreate = vi.fn();
+const mockTransaction = vi.fn();
+const mockExecuteRaw = vi.fn();
+const mockTxFindFirst = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    userProject: {
+      findFirst: mockUserProjectFindFirst,
+      create: mockUserProjectCreate,
+    },
+    project: {
+      create: mockProjectCreate,
+    },
+    $transaction: mockTransaction,
+  },
+}));
+
+const { DEFAULT_PROJECT_NAME, attachProjectId, ensureDefaultProject } =
+  await import("@/lib/project");
+
+describe("ensureDefaultProject", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Run the callback against the same mocked client, as Prisma does.
+    mockTransaction.mockImplementation(
+      async (fn: (tx: unknown) => Promise<unknown>) =>
+        await fn({
+          $executeRaw: mockExecuteRaw,
+          project: { create: mockProjectCreate },
+          userProject: { create: mockUserProjectCreate, findFirst: mockTxFindFirst },
+        }),
+    );
+  });
+
+  it("returns the existing project when the user already owns one", async () => {
+    mockUserProjectFindFirst.mockResolvedValue({ project_id: "proj-existing" });
+
+    const result = await ensureDefaultProject("user-1");
+
+    expect(result).toBe("proj-existing");
+    expect(mockProjectCreate).not.toHaveBeenCalled();
+    expect(mockUserProjectCreate).not.toHaveBeenCalled();
+  });
+
+  it("only considers OWNER and EDITOR memberships of live projects", async () => {
+    mockUserProjectFindFirst.mockResolvedValue({ project_id: "proj-existing" });
+
+    await ensureDefaultProject("user-1");
+
+    expect(mockUserProjectFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          user_id: "user-1",
+          role: { in: ["OWNER", "EDITOR"] },
+          project: { deleted_at: null },
+        },
+        orderBy: { created_at: "asc" },
+      }),
+    );
+  });
+
+  // This is the regression: a self-registered user has no membership at all, so
+  // the create pages redirected to the dashboard (issue #64).
+  it("provisions a project with an OWNER membership when the user has none", async () => {
+    mockUserProjectFindFirst.mockResolvedValue(null);
+    mockProjectCreate.mockResolvedValue({ id: "proj-new" });
+
+    const result = await ensureDefaultProject("user-1");
+
+    expect(result).toBe("proj-new");
+    expect(mockProjectCreate).toHaveBeenCalledWith({
+      data: { name: DEFAULT_PROJECT_NAME },
+    });
+    expect(mockUserProjectCreate).toHaveBeenCalledWith({
+      data: { user_id: "user-1", project_id: "proj-new", role: "OWNER" },
+    });
+  });
+
+  it("creates the project and the membership in a single transaction", async () => {
+    mockUserProjectFindFirst.mockResolvedValue(null);
+    mockProjectCreate.mockResolvedValue({ id: "proj-new" });
+
+    await ensureDefaultProject("user-1");
+
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null instead of throwing when provisioning fails, so login still succeeds", async () => {
+    mockUserProjectFindFirst.mockResolvedValue(null);
+    mockTransaction.mockRejectedValue(new Error("db down"));
+
+    await expect(ensureDefaultProject("user-1")).resolves.toBeNull();
+  });
+
+  // Two parallel session reads (a page render plus an RSC prefetch) would both
+  // see "no membership" and each create a project, leaving the user owning a
+  // duplicate they never asked for. The lock serialises them per user.
+  it("takes a per-user advisory lock before creating anything", async () => {
+    mockUserProjectFindFirst.mockResolvedValue(null);
+    mockTxFindFirst.mockResolvedValue(null);
+    mockProjectCreate.mockResolvedValue({ id: "proj-new" });
+
+    await ensureDefaultProject("user-1");
+
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
+    const sql = mockExecuteRaw.mock.calls[0]?.[0] as { strings?: string[] } | string[];
+    const text = Array.isArray(sql) ? sql.join("") : (sql.strings?.join("") ?? String(sql));
+    expect(text).toContain("pg_advisory_xact_lock");
+  });
+
+  it("re-checks inside the lock and reuses the project the other request created", async () => {
+    mockUserProjectFindFirst.mockResolvedValue(null); // lost the race before the lock
+    mockTxFindFirst.mockResolvedValue({ project_id: "proj-from-winner" }); // winner got there first
+
+    const result = await ensureDefaultProject("user-1");
+
+    expect(result).toBe("proj-from-winner");
+    expect(mockProjectCreate).not.toHaveBeenCalled();
+    expect(mockUserProjectCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("attachProjectId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTransaction.mockImplementation(
+      async (fn: (tx: unknown) => Promise<unknown>) =>
+        await fn({
+          $executeRaw: mockExecuteRaw,
+          project: { create: mockProjectCreate },
+          userProject: { create: mockUserProjectCreate, findFirst: mockTxFindFirst },
+        }),
+    );
+  });
+
+  // The reporter of #64 was already signed in, and the JWT carries projectId
+  // only from sign-in, so their 30-day token would never pick the new project up.
+  it("fills in a projectId that the token never carried", async () => {
+    mockUserProjectFindFirst.mockResolvedValue({ project_id: "proj-1" });
+    const session = { user: { id: "user-1" } as { id: string; projectId?: string } };
+
+    await attachProjectId(session);
+
+    expect(session.user.projectId).toBe("proj-1");
+  });
+
+  it("leaves an existing projectId untouched and does not hit the database", async () => {
+    const session = { user: { id: "user-1", projectId: "proj-kept" } };
+
+    await attachProjectId(session);
+
+    expect(session.user.projectId).toBe("proj-kept");
+    expect(mockUserProjectFindFirst).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when there is no user id to resolve against", async () => {
+    const session = { user: {} as { id?: string; projectId?: string } };
+
+    await attachProjectId(session);
+
+    expect(session.user.projectId).toBeUndefined();
+    expect(mockUserProjectFindFirst).not.toHaveBeenCalled();
+  });
+
+  it("leaves projectId unset when provisioning fails", async () => {
+    mockUserProjectFindFirst.mockResolvedValue(null);
+    mockTransaction.mockRejectedValue(new Error("db down"));
+    const session = { user: { id: "user-1" } as { id: string; projectId?: string } };
+
+    await attachProjectId(session);
+
+    expect(session.user.projectId).toBeUndefined();
+  });
+
+  it("tolerates a session with no user at all", async () => {
+    await expect(attachProjectId({})).resolves.toBeUndefined();
+    expect(mockUserProjectFindFirst).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -1,0 +1,98 @@
+import type { ProjectRole } from "@prisma/client";
+
+import { prisma } from "@/lib/db";
+
+/**
+ * Name given to the project provisioned on first sign-in. The default locale is
+ * `de`, and Epic 3.1 adds renaming, so this is deliberately not translated —
+ * `authorize()` has no request locale to translate against.
+ */
+export const DEFAULT_PROJECT_NAME = "Forschungsprojekt";
+
+/**
+ * The membership that decides the active project. Declared once because
+ * `ensureDefaultProject` has to ask the same question twice — before taking the
+ * lock and again inside it — and the two must not drift apart.
+ */
+const WRITABLE_ROLES: ProjectRole[] = ["OWNER", "EDITOR"];
+
+const DEFAULT_PROJECT_MEMBERSHIP = (userId: string) => ({
+  where: {
+    user_id: userId,
+    role: { in: WRITABLE_ROLES },
+    // A soft-deleted project must not be handed out as the active one.
+    project: { deleted_at: null },
+  },
+  orderBy: { created_at: "asc" as const },
+  select: { project_id: true },
+});
+
+/**
+ * Fill `session.user.projectId` in, in place, when the JWT does not carry it.
+ *
+ * The claim is written into the token at sign-in only, and the token lives 30
+ * days — so a user signed in before default-project provisioning existed would
+ * stay unable to create anything for a month (#64). Resolving it per session
+ * read costs one indexed query, and only while the claim is still missing.
+ *
+ * Kept here rather than inline in the `session` callback so it can be tested
+ * without standing up next-auth, and mutates rather than returns so the caller
+ * can hand next-auth back its own `Session` type unchanged.
+ */
+export async function attachProjectId(session: unknown): Promise<void> {
+  const target = session as { user?: { id?: string; projectId?: string } } | null;
+  if (!target?.user || target.user.projectId || !target.user.id) return;
+
+  const projectId = await ensureDefaultProject(target.user.id);
+  if (projectId) target.user.projectId = projectId;
+}
+
+/**
+ * Resolve the user's default project, creating one if they have none.
+ *
+ * Until the Epic 3.1 project switcher exists, `projectId` is derived from the
+ * user's first OWNER/EDITOR project (roadmap: "temporary project scope
+ * scaffold"). Nothing ever created that project for a self-registered user, so
+ * every account made through `/auth/register` had no project — which made the
+ * create pages redirect to the dashboard and every list render empty (#64).
+ *
+ * Provisioning here rather than in the register route also repairs accounts that
+ * were created before this fix: they get their project on next sign-in, with no
+ * backfill migration.
+ *
+ * Returns `null` if provisioning fails. A user without a project sees empty
+ * lists, which is bad but recoverable; failing to sign in is worse.
+ */
+export async function ensureDefaultProject(userId: string): Promise<string | null> {
+  const existing = await prisma.userProject.findFirst(DEFAULT_PROJECT_MEMBERSHIP(userId));
+
+  if (existing) return existing.project_id;
+
+  try {
+    return await prisma.$transaction(async (tx) => {
+      // Two session reads can run in parallel for one user — a page render and
+      // an RSC prefetch, say — and both would pass the check above and create a
+      // project, leaving the user owning a duplicate they never asked for. The
+      // advisory lock is held to the end of the transaction and serialises
+      // provisioning per user; a plain unique constraint cannot express this,
+      // because the two rows differ in project_id.
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${userId}, 0))`;
+
+      // Whoever waited on the lock must not create a second project.
+      const won = await tx.userProject.findFirst(DEFAULT_PROJECT_MEMBERSHIP(userId));
+      if (won) return won.project_id;
+
+      const project = await tx.project.create({ data: { name: DEFAULT_PROJECT_NAME } });
+      await tx.userProject.create({
+        data: { user_id: userId, project_id: project.id, role: "OWNER" },
+      });
+      return project.id;
+    });
+  } catch (err) {
+    console.error("[project] default project provisioning failed", {
+      userId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}


### PR DESCRIPTION
Fixes #64.

## What was wrong

`POST /api/auth/register` creates a `User` row and nothing else — no `Project`, no
`UserProject`. But `session.user.projectId` is derived solely from the user's first
`OWNER`/`EDITOR` membership (the "temporary project scope scaffold" the roadmap describes for
Epic 2.1). Nothing ever created that membership, so a self-registered account had no
`projectId` — permanently.

All three create pages then take the same branch:

```ts
if (!projectId) {
  // TODO: Epic 3.1 — redirect to project creation
  redirect(`/${locale}/dashboard`);
}
```

`persons/new/page.tsx:27`, `events/new/page.tsx:19`, `sources/new/page.tsx:32` — exactly the
reported symptom. The list pages guard on `if (projectId)` too, which is why the empty state was
showing in the first place.

**Measured** on the production Neon branch `br-old-grass-a9acitgb` (read-only):

| email | verified | last login | membership |
|---|---|---|---|
| `mathis.thomsen@mail.de` | yes | 2026-04-03 | `OWNER` |
| `info@mathisthomsen.de` | yes | **2026-08-11** | **none** |

The second is a self-registration from the day before the report, with zero memberships. On the
dev branch, 116 of 118 users have none.

## The fix

`src/lib/project.ts` — `ensureDefaultProject(userId)` returns the user's first live
`OWNER`/`EDITOR` project or creates one with an `OWNER` membership. It returns `null` rather than
throwing if provisioning fails: a user without a project sees empty lists, which is recoverable;
failing to sign in is not.

Wired in at two points:

1. **`authorize()`** — provisions at sign-in, replacing the inline lookup.
2. **the `session` callback** — backfills `projectId` for sessions minted before this existed.

Provisioning at sign-in rather than in the register route means pre-existing accounts repair
themselves with no backfill migration, and an unverified registration leaves no orphan project.

### Two things I got wrong first, and measured

**`jwt` vs `session`.** I first put the backfill in the `jwt` callback. It never ran: with the
JWT strategy `jwt` fires only on sign-in and on `updateAge` rotation, so an ordinary page request
never reached it and the membership count stayed at 0. `session` runs on every `auth()` call. It
stays in the Node-side config — `auth.config.ts` must remain Prisma-free for the Edge middleware.

**A duplicate-project race.** A session read can happen twice concurrently (page render plus an
RSC prefetch), and both attempts passed the "no membership" check. Measured on the dev branch:

| | projects created by 8 concurrent calls |
|---|---|
| without lock | **8** |
| with lock | **1** |

Fixed with a transaction-scoped `pg_advisory_xact_lock` keyed on the user, plus a re-check inside
the lock. A unique constraint cannot express this — the competing rows differ in `project_id`.

## Verification

Against a **production build** (`next build && next start`) on the dev Neon branch, driving the
app's own credentials endpoint, with a deliberately `projectId`-less token and zero memberships:

| route | before | after |
|---|---|---|
| `/de/persons/new` | `NEXT_REDIRECT`, no form | `<h1>Neue Person anlegen</h1>` |
| `/de/events/new` | `NEXT_REDIRECT`, no form | `<h1>Neues Ereignis anlegen</h1>` |
| `/de/sources/new` | `NEXT_REDIRECT`, no form | `<h1>Neue Quelle</h1>` |

`POST /api/persons` returns **201** and the record persists. The before column was produced by
stashing this change and rebuilding, not inferred. All test data removed afterwards (verified: 0
residual users, 0 residual projects).

1325 unit tests pass (12 new, covering both the redirect cause and the race), `pnpm lint` and
`tsc --noEmit` clean.

## Scope notes

- **Authorization is unchanged.** `ensureDefaultProject` only ever reads `user_id: <session
  user>` and creates a project for that user; it takes no client-supplied project or entity ID.
  The existing role checks on the API routes are untouched.
- The provisioned project is named `Forschungsprojekt`, untranslated — `authorize()` has no
  request locale, and Epic 3.1 adds renaming. Flagged rather than guessed at.
- A new project has **no** `EventType` rows (the seed creates those only for the demo project),
  so the event form's type dropdown starts empty. `event_type_id` is nullable, so event creation
  works — cosmetic, and not widened into this PR.
- Two local-environment findings surfaced while verifying (dev *and* production builds serve
  404ing chunk references locally; `AUTH_URL` is pinned to port 3000, which silently invalidates
  sessions on any other port). Both belong to #61 and are reported there, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)